### PR TITLE
Make setArweaveHashes function virtual and simplify non-implemented

### DIFF
--- a/contracts/dynamic/DynamicArweaveHash.sol
+++ b/contracts/dynamic/DynamicArweaveHash.sol
@@ -40,19 +40,11 @@ abstract contract DynamicArweaveHash is CreatorExtension, Ownable, ICreatorExten
                                          '", "image":"https://arweave.net/',_getImageHash(),'"}'));
     }
 
-    function _getName() internal view virtual returns(string memory) {
-        revert("Must implement");
-    }
+    function _getName() internal view virtual returns(string memory);
 
-    function _getDescription() internal view virtual returns(string memory) {
-        revert("Must implement");
-    }
+    function _getDescription() internal view virtual returns(string memory);
 
-    function _getImageHash() internal view virtual returns(string memory) {
-        revert("Must implement");
-    }
+    function _getImageHash() internal view virtual returns(string memory);
 
-    function setArweaveHashes(string[] memory _arweaveHashes) external {
-        revert("Must implement");
-    }
+    function setArweaveHashes(string[] memory _arweaveHashes) external virtual;
 }


### PR DESCRIPTION
While implementing this contract in the `artists-extensions-solidity` package, I noticed we need `setArweaveHashes` to be virtual so we can override it.

Signed-off-by: campionfellin <campionfellin@gmail.com>