### PR TITLE
Allow for changing of redemptionMax() by Admin via Override

### DIFF
--- a/contracts/redeem/ERC721/ERC721RedeemBase.sol
+++ b/contracts/redeem/ERC721/ERC721RedeemBase.sol
@@ -43,7 +43,7 @@ abstract contract ERC721RedeemBase is ERC721SingleCreatorExtension, RedeemBase, 
     /**
      * @dev See {IERC721RedeemBase-redemptionMax}
      */
-    function redemptionMax() external view virtual override returns(uint16) {
+    function redemptionMax() public view virtual override returns(uint16) {
         return _redemptionMax;
     }
 
@@ -58,7 +58,7 @@ abstract contract ERC721RedeemBase is ERC721SingleCreatorExtension, RedeemBase, 
      * @dev See {IERC721RedeemBase-redemptionRemaining}
      */
     function redemptionRemaining() public view virtual override returns(uint16) {
-        return _redemptionMax-_redemptionCount;
+        return redemptionMax() - _redemptionCount;
     }
 
     /**
@@ -79,7 +79,7 @@ abstract contract ERC721RedeemBase is ERC721SingleCreatorExtension, RedeemBase, 
      * @dev mint token that was redeemed for
      */
     function _mintRedemption(address to) internal virtual returns (uint256) {
-        require(_redemptionCount < _redemptionMax, "Redeem: No redemptions remaining");
+        require(_redemptionCount < redemptionMax(), "Redeem: No redemptions remaining");
         _redemptionCount++;
         
         // Mint token


### PR DESCRIPTION
## Proposal

Weird idea:

How a client would now override and change the max as admin:
```
    uint16  myNewMax;

    function setMaxRedemption(uint16 newMax) public adminRequired {
        myNewMax = newMax;
    }

   /**
     * @dev See {IERC721RedeemBase-redemptionMax}
     */
    function redemptionMax() public view virtual override returns(uint16) {
        return myNewMax;
    }
```

I think this would allow for people to update the max in case that's something they want to do. Helpful in the testing stages if/when we put this into Manifold Studio, as users may deploy to rinkeby and then realize they actually want to have more assets in the burn-redeem than what they originally set.

One major drawback is `maxRedemption` becomes gas heavy and `public` as it is called both externally and internally. My approach keeps all references to a single source of truth, the method `maxRedemption()` and not variable `_maxRedemption` set in the constructor.