### PR TITLE
mark _mint as virtual for overriding

### DIFF
--- a/contracts/redeem/ERC721/ERC721RedeemBase.sol
+++ b/contracts/redeem/ERC721/ERC721RedeemBase.sol
@@ -93,7 +93,7 @@ abstract contract ERC721RedeemBase is ERC721SingleCreatorExtension, RedeemBase, 
     /**
      * @dev override if you want to perform different mint functionality
      */
-    function _mint(address to, uint16) internal returns (uint256) {
+    function _mint(address to, uint16) internal virtual returns (uint256) {
         return IERC721CreatorCore(_creator).mintExtension(to);
     }
 


### PR DESCRIPTION
This method should be overridable to allow for changing mint behavior. This can't be done without `virtual`.