### PR TITLE
[draft] feat: support opensea operator filter

### DIFF
--- a/contracts/operatorfilter/CreatorOperatorFilterer.sol
+++ b/contracts/operatorfilter/CreatorOperatorFilterer.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/// @author: manifold.xyz
+
+import "operator-filter-registry/src/IOperatorFilterRegistry.sol";
+import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import "@manifoldxyz/libraries-solidity/contracts/access/AdminControl.sol";
+
+/**
+ * @title  CreatorOperatorFilterer
+ * @notice This is a port of https://github.com/ProjectOpenSea/operator-filter-registry/blob/0968789ad7e78418b9fa7cf7aff012f2e883120b/src/OperatorFilterer.sol
+ *         Abstract contract whose constructor automatically registers and optionally subscribes to or copies another
+ *         registrant's entries in the OperatorFilterRegistry.
+ * @dev    This smart contract is meant to be inherited by token contracts so they can use the following:
+ *         - `onlyAllowedOperator` modifier for `transferFrom` and `safeTransferFrom` methods.
+ *         - `onlyAllowedOperatorApproval` modifier for `approve` and `setApprovalForAll` methods.
+ */
+abstract contract CreatorOperatorFilterer is AdminControl {
+    error OperatorNotAllowed(address operator);
+
+    IOperatorFilterRegistry internal _operatorFilterRegistry;
+
+    constructor(address operatorFilterRegistry, address subscriptionOrRegistrantToCopy, bool subscribe) {
+        switchRegistry(operatorFilterRegistry, subscriptionOrRegistrantToCopy, subscribe);
+    }
+
+    function switchRegistry(address operatorFilterRegistry, address subscriptionOrRegistrantToCopy, bool subscribe)
+        public
+        adminRequired
+    {
+        require(operatorFilterRegistry.code.length > 0, "IOperatorFilterRegistry not found");
+
+        if (address(_operatorFilterRegistry).code.length > 0) {
+            _operatorFilterRegistry.unregister(address(this));
+        }
+
+        _operatorFilterRegistry = IOperatorFilterRegistry(operatorFilterRegistry);
+
+        if (subscribe) {
+            _operatorFilterRegistry.registerAndSubscribe(address(this), subscriptionOrRegistrantToCopy);
+        } else {
+            if (subscriptionOrRegistrantToCopy != address(0)) {
+                _operatorFilterRegistry.registerAndCopyEntries(address(this), subscriptionOrRegistrantToCopy);
+            } else {
+                _operatorFilterRegistry.register(address(this));
+            }
+        }
+    }
+
+    function _checkFilterOperator(address operator) internal view virtual {
+        // Check registry code length to facilitate testing in environments without a deployed registry.
+        if (address(_operatorFilterRegistry).code.length > 0) {
+            if (!_operatorFilterRegistry.isOperatorAllowed(address(this), operator)) {
+                revert OperatorNotAllowed(operator);
+            }
+        }
+    }
+
+    modifier creatorAdminRequired(address creator) {
+        require(IAdminControl(creator).isAdmin(msg.sender), "Must be owner or admin of creator contract");
+        _;
+    }
+
+    modifier onlyAllowedOperator(address operator, address from) {
+        // Allow spending tokens from addresses with balance
+        // Note that this still allows listings and marketplaces with escrow to transfer tokens if transferred
+        // from an EOA.
+        if (from != operator) {
+            _checkFilterOperator(operator);
+        }
+        _;
+    }
+
+    modifier onlyAllowedOperatorApproval(address operator) {
+        _checkFilterOperator(operator);
+        _;
+    }
+}

--- a/contracts/operatorfilter/ERC1155OperatorFilterer.sol
+++ b/contracts/operatorfilter/ERC1155OperatorFilterer.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/// @author: manifold.xyz
+
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "./CreatorOperatorFilterer.sol";
+import "../creator/extensions/ERC1155/ERC1155CreatorExtensionApproveTransfer.sol";
+
+contract ERC1155OperatorFilterer is ERC1155CreatorExtensionApproveTransfer, CreatorOperatorFilterer {
+    constructor(address operatorFilterRegistry, address subscriptionOrRegistrantToCopy, bool subscribe)
+        CreatorOperatorFilterer(operatorFilterRegistry, subscriptionOrRegistrantToCopy, subscribe)
+    {}
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override (ERC1155CreatorExtensionApproveTransfer, AdminControl)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+
+    function approveTransfer(address operator, address from, address, uint256[] calldata, uint256[] calldata)
+        external
+        view
+        override
+        onlyAllowedOperator(operator, from)
+        returns (bool)
+    {
+        return true;
+    }
+
+    function mintNew(address creator, address[] calldata to, uint256[] calldata amounts, string[] calldata uris)
+        external
+        creatorAdminRequired(creator)
+        returns (uint256[] memory)
+    {
+        return IERC1155CreatorCore(creator).mintExtensionNew(to, amounts, uris);
+    }
+
+    //TODO: other 1155 mint functions
+}

--- a/contracts/operatorfilter/ERC721OperatorFilterer.sol
+++ b/contracts/operatorfilter/ERC721OperatorFilterer.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/// @author: manifold.xyz
+
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "./CreatorOperatorFilterer.sol";
+import "../creator/extensions/ERC721/ERC721CreatorExtensionApproveTransfer.sol";
+
+contract ERC721OperatorFilterer is ERC721CreatorExtensionApproveTransfer, CreatorOperatorFilterer {
+    constructor(address operatorFilterRegistry, address subscriptionOrRegistrantToCopy, bool subscribe)
+        CreatorOperatorFilterer(operatorFilterRegistry, subscriptionOrRegistrantToCopy, subscribe)
+    {}
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override (ERC721CreatorExtensionApproveTransfer, AdminControl)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+
+    function approveTransfer(address operator, address from, address, uint256)
+        external
+        view
+        override
+        onlyAllowedOperator(operator, from)
+        returns (bool)
+    {
+        return true;
+    }
+
+    function mint(address creator, address recipient, string calldata tokenURI)
+        external
+        creatorAdminRequired(creator)
+        returns (uint256)
+    {
+        return IERC721CreatorCore(creator).mintExtension(recipient, tokenURI);
+    }
+
+    //TODO: other 721 mint functions
+}


### PR DESCRIPTION
Implements opensea's operator filter registry via extension.

notes
- One extension per creator contract (or one extension per creator) is required due to how [OperatorFiltererRegistry](https://github.com/ProjectOpenSea/operator-filter-registry/blob/main/src/OperatorFilterRegistry.sol#L32) authenticates.

todo
- tests
- more mint methods
- etc