### PR TITLE
fix: ClaimMint event should include `claimIndex`

### DIFF
--- a/contracts/manifold/lazyclaim/ERC1155LazyPayableClaim.sol
+++ b/contracts/manifold/lazyclaim/ERC1155LazyPayableClaim.sol
@@ -239,7 +239,7 @@ contract ERC1155LazyPayableClaim is IERC165, IERC1155LazyPayableClaim, ICreatorE
         (bool sent, ) = claim.paymentReceiver.call{value: msg.value}("");
         require(sent, "Failed to transfer to receiver");
 
-        emit ClaimMint(creatorContractAddress, _claimTokenIds[creatorContractAddress][claimIndex]);
+        emit ClaimMint(creatorContractAddress, claimIndex);
     }
 
     /**


### PR DESCRIPTION
- all ClaimMint events for 1155s have `claimIndex` = 0.