### PR TITLE
refactor: reduce burn redeem contract size

### DIFF
--- a/packages/manifold/contracts/burnredeem/BurnRedeemCore.sol
+++ b/packages/manifold/contracts/burnredeem/BurnRedeemCore.sol
@@ -226,7 +226,7 @@ abstract contract BurnRedeemCore is ERC165, AdminControl, ReentrancyGuard, IBurn
         uint256 payableCost = burnRedeemInstance.cost;
         uint256 cost = burnRedeemInstance.cost;
         if (!isActiveMember) {
-            payableCost += _getManifoldFee(burnTokens.length);
+            payableCost += burnTokens.length <= 1 ? BURN_FEE : MULTI_BURN_FEE;
         }
         if (burnRedeemCount > 1) {
             payableCost *= burnRedeemCount;
@@ -365,7 +365,7 @@ abstract contract BurnRedeemCore is ERC165, AdminControl, ReentrancyGuard, IBurn
         // 3. They are an active member (because no fee payment can be sent with a transfer)
         _validateReceivedInput(burnRedeemInstance.cost, burnRedeemInstance.burnSet.length, burnRedeemInstance.burnSet[0].requiredCount, from);
 
-        uint256 burnRedeemCount = _getAvailableBurnRedeemCount(burnRedeemInstance.totalSupply, burnRedeemInstance.redeemedCount, burnRedeemInstance.redeemAmount, 1, true);
+        _getAvailableBurnRedeemCount(burnRedeemInstance.totalSupply, burnRedeemInstance.redeemedCount, burnRedeemInstance.redeemAmount, 1, true);
 
         // Check that the burn token is valid
         BurnItem memory burnItem = burnRedeemInstance.burnSet[0].items[burnItemIndex];
@@ -494,14 +494,6 @@ abstract contract BurnRedeemCore is ERC165, AdminControl, ReentrancyGuard, IBurn
             }
             unchecked { ++i; }
         }
-    }
-
-
-    /**
-     * Helper to get the Manifold fee for the sender
-     */
-    function _getManifoldFee(uint256 burnTokenCount) private pure returns(uint256 fee) {
-        fee = burnTokenCount <= 1 ? BURN_FEE : MULTI_BURN_FEE;
     }
 
     /**

--- a/packages/manifold/contracts/burnredeem/BurnRedeemLib.sol
+++ b/packages/manifold/contracts/burnredeem/BurnRedeemLib.sol
@@ -54,6 +54,15 @@ library BurnRedeemLib {
     event BurnRedeemUpdated(address indexed creatorContract, uint256 indexed instanceId);
     event BurnRedeemMint(address indexed creatorContract, uint256 indexed instanceId, uint256 indexed tokenId, uint32 redeemedCount);
 
+    error BurnRedeemAlreadyInitialized();
+    error InvalidBurnItem();
+    error InvalidBurnToken();
+    error InvalidMerkleProof();
+    error InvalidStorageProtocol();
+    error InvalidPaymentReceiver();
+    error InvalidDates();
+    error InvalidInput();
+
     /**
      * Initialiazes a burn redeem with base parameters
      */
@@ -65,7 +74,9 @@ library BurnRedeemLib {
         IBurnRedeemCore.BurnRedeemParameters calldata burnRedeemParameters
     ) public {
         // Sanity checks
-        require(burnRedeemInstance.storageProtocol == IBurnRedeemCore.StorageProtocol.INVALID, "Burn redeem already initialized");
+        if (burnRedeemInstance.storageProtocol != IBurnRedeemCore.StorageProtocol.INVALID) {
+            revert BurnRedeemAlreadyInitialized();
+        }
         _validateParameters(burnRedeemParameters);
 
         // Create the burn redeem
@@ -86,10 +97,14 @@ library BurnRedeemLib {
         IBurnRedeemCore.BurnRedeemParameters calldata burnRedeemParameters
     ) public {
         // Sanity checks
-        require(burnRedeemInstance.storageProtocol != IBurnRedeemCore.StorageProtocol.INVALID, "Burn redeem not initialized");
+        if (burnRedeemInstance.storageProtocol == IBurnRedeemCore.StorageProtocol.INVALID) {
+            revert IBurnRedeemCore.BurnRedeemDoesNotExist(instanceId);
+        }
         _validateParameters(burnRedeemParameters);
         // The current redeemedCount must be divisible by redeemAmount
-        require(burnRedeemInstance.redeemedCount % burnRedeemParameters.redeemAmount == 0, "Invalid amount");
+        if (burnRedeemInstance.redeemedCount % burnRedeemParameters.redeemAmount != 0) {
+            revert IBurnRedeemCore.InvalidRedeemAmount();
+        }
 
         // Overwrite the existing burnRedeem
         _setParameters(burnRedeemInstance, burnRedeemParameters);
@@ -117,28 +132,42 @@ library BurnRedeemLib {
         if (burnItem.validationType == IBurnRedeemCore.ValidationType.ANY) {
             return;
         }
-        require(contractAddress == burnItem.contractAddress, "Invalid burn token");
+        if (contractAddress != burnItem.contractAddress) {
+            revert InvalidBurnToken();
+        }
         if (burnItem.validationType == IBurnRedeemCore.ValidationType.CONTRACT) {
             return;
         } else if (burnItem.validationType == IBurnRedeemCore.ValidationType.RANGE) {
-            require(tokenId >= burnItem.minTokenId && tokenId <= burnItem.maxTokenId, "Invalid token ID");
+            if (tokenId < burnItem.minTokenId || tokenId > burnItem.maxTokenId) {
+                revert IBurnRedeemCore.InvalidToken(tokenId);
+            }
             return;
         } else if (burnItem.validationType == IBurnRedeemCore.ValidationType.MERKLE_TREE) {
             bytes32 leaf = keccak256(abi.encodePacked(tokenId));
-            require(MerkleProof.verify(merkleProof, burnItem.merkleRoot, leaf), "Invalid merkle proof");
+            if (!MerkleProof.verify(merkleProof, burnItem.merkleRoot, leaf)) {
+                revert InvalidMerkleProof();
+            }
             return;
         }
-        revert("Invalid burn item");
+        revert InvalidBurnItem();
     }
 
         /**
      * Helper to validate the parameters for a burn redeem
      */
     function _validateParameters(IBurnRedeemCore.BurnRedeemParameters calldata burnRedeemParameters) internal pure {
-        require(burnRedeemParameters.storageProtocol != IBurnRedeemCore.StorageProtocol.INVALID, "Storage protocol invalid");
-        require(burnRedeemParameters.paymentReceiver != address(0), "Payment receiver required");
-        require(burnRedeemParameters.endDate == 0 || burnRedeemParameters.startDate < burnRedeemParameters.endDate, "startDate after endDate");
-        require(burnRedeemParameters.totalSupply % burnRedeemParameters.redeemAmount == 0, "Remainder left from totalSupply");
+        if (burnRedeemParameters.storageProtocol == IBurnRedeemCore.StorageProtocol.INVALID) {
+            revert InvalidStorageProtocol();
+        }
+        if (burnRedeemParameters.paymentReceiver == address(0)) {
+            revert InvalidPaymentReceiver();
+        }
+        if (burnRedeemParameters.endDate != 0 && burnRedeemParameters.startDate >= burnRedeemParameters.endDate) {
+            revert InvalidDates();
+        }
+        if (burnRedeemParameters.totalSupply % burnRedeemParameters.redeemAmount != 0) {
+            revert IBurnRedeemCore.InvalidRedeemAmount();
+        }
     }
 
     /**
@@ -163,21 +192,23 @@ library BurnRedeemLib {
         for (uint256 i; i < burnGroups.length;) {
             burnRedeemInstance.burnSet.push();
             IBurnRedeemCore.BurnGroup storage burnGroup = burnRedeemInstance.burnSet[i];
-            require(
-                burnGroups[i].requiredCount > 0 &&
-                burnGroups[i].requiredCount <= burnGroups[i].items.length,
-                "Invalid input"
-            );
+            if (burnGroups[i].requiredCount == 0 || burnGroups[i].requiredCount > burnGroups[i].items.length) {
+                revert InvalidInput();
+            }
             burnGroup.requiredCount = burnGroups[i].requiredCount;
             for (uint256 j; j < burnGroups[i].items.length;) {
                 IBurnRedeemCore.BurnItem memory burnItem = burnGroups[i].items[j];
-                require(
-                    (
-                        (burnItem.tokenSpec == IBurnRedeemCore.TokenSpec.ERC1155 && burnItem.amount > 0) ||
-                        (burnItem.tokenSpec == IBurnRedeemCore.TokenSpec.ERC721 && burnItem.amount == 0)
-                    ) &&
-                    burnItem.validationType != IBurnRedeemCore.ValidationType.INVALID,
-                    "Invalid input");
+                IBurnRedeemCore.TokenSpec tokenSpec = burnItem.tokenSpec;
+                uint256 amount = burnItem.amount;
+                if (
+                    !(
+                        (tokenSpec == IBurnRedeemCore.TokenSpec.ERC1155 && amount > 0) ||
+                        (tokenSpec == IBurnRedeemCore.TokenSpec.ERC721 && amount == 0)
+                    ) || 
+                    burnItem.validationType == IBurnRedeemCore.ValidationType.INVALID
+                ) {
+                    revert InvalidInput();
+                }
                 burnGroup.items.push(burnGroups[i].items[j]);
                 unchecked { ++j; }
             }

--- a/packages/manifold/contracts/burnredeem/ERC1155BurnRedeem.sol
+++ b/packages/manifold/contracts/burnredeem/ERC1155BurnRedeem.sol
@@ -92,10 +92,7 @@ contract ERC1155BurnRedeem is BurnRedeemCore, IERC1155BurnRedeem {
      * See {ICreatorExtensionTokenURI-tokenURI}.
      */
     function tokenURI(address creatorContractAddress, uint256 tokenId) external override view returns(string memory uri) {
-        uint256 instanceId = _redeemInstanceIds[creatorContractAddress][tokenId];
-        if (instanceId == 0) {
-            revert InvalidToken(tokenId);
-        }
+        uint256 instanceId = _getRedeemInstanceId(creatorContractAddress, tokenId);
         BurnRedeem memory burnRedeem = _burnRedeems[creatorContractAddress][instanceId];
 
         string memory prefix = "";
@@ -111,10 +108,7 @@ contract ERC1155BurnRedeem is BurnRedeemCore, IERC1155BurnRedeem {
      * See {IBurnRedeemCore-getBurnRedeemForToken}.
      */
     function getBurnRedeemForToken(address creatorContractAddress, uint256 tokenId) external override view returns(uint256 instanceId, BurnRedeem memory burnRedeem) {
-        instanceId = _redeemInstanceIds[creatorContractAddress][tokenId];
-        if (instanceId == 0) {
-            revert InvalidToken(tokenId);
-        }
+        instanceId = _getRedeemInstanceId(creatorContractAddress, tokenId);
         burnRedeem = _burnRedeems[creatorContractAddress][instanceId];
     }
 
@@ -125,6 +119,13 @@ contract ERC1155BurnRedeem is BurnRedeemCore, IERC1155BurnRedeem {
         tokenId = _redeemTokenIds[creatorContractAddress][instanceId];
         if (tokenId == 0) {
             revert BurnRedeemDoesNotExist(instanceId);
+        }
+    }
+
+    function _getRedeemInstanceId(address creatorContractAddress, uint256 tokenId) internal view returns(uint256 instanceId) {
+        instanceId = _redeemInstanceIds[creatorContractAddress][tokenId];
+        if (instanceId == 0) {
+            revert InvalidToken(tokenId);
         }
     }
 }

--- a/packages/manifold/contracts/burnredeem/ERC1155BurnRedeem.sol
+++ b/packages/manifold/contracts/burnredeem/ERC1155BurnRedeem.sol
@@ -29,7 +29,8 @@ contract ERC1155BurnRedeem is BurnRedeemCore, IERC1155BurnRedeem {
         address creatorContractAddress,
         uint256 instanceId,
         BurnRedeemParameters calldata burnRedeemParameters
-    ) external override creatorAdminRequired(creatorContractAddress) {
+    ) external override {
+        _validateAdmin(creatorContractAddress);
         _initialize(creatorContractAddress, 0, instanceId, burnRedeemParameters);
 
         // Mint a new token with amount '0' to the creator
@@ -49,7 +50,8 @@ contract ERC1155BurnRedeem is BurnRedeemCore, IERC1155BurnRedeem {
         address creatorContractAddress,
         uint256 instanceId,
         BurnRedeemParameters calldata burnRedeemParameters
-    ) external override creatorAdminRequired(creatorContractAddress) {
+    ) external override {
+        _validateAdmin(creatorContractAddress);
         _update(creatorContractAddress, instanceId, burnRedeemParameters);
     }
 
@@ -61,7 +63,8 @@ contract ERC1155BurnRedeem is BurnRedeemCore, IERC1155BurnRedeem {
         uint256 instanceId,
         StorageProtocol storageProtocol,
         string calldata location
-    ) external override creatorAdminRequired(creatorContractAddress) {
+    ) external override {
+        _validateAdmin(creatorContractAddress);
         BurnRedeem storage burnRedeemInstance = _getBurnRedeem(creatorContractAddress, instanceId);
         burnRedeemInstance.storageProtocol = storageProtocol;
         burnRedeemInstance.location = location;
@@ -90,7 +93,9 @@ contract ERC1155BurnRedeem is BurnRedeemCore, IERC1155BurnRedeem {
      */
     function tokenURI(address creatorContractAddress, uint256 tokenId) external override view returns(string memory uri) {
         uint256 instanceId = _redeemInstanceIds[creatorContractAddress][tokenId];
-        require(instanceId > 0, "Token does not exist");
+        if (instanceId == 0) {
+            revert InvalidToken(tokenId);
+        }
         BurnRedeem memory burnRedeem = _burnRedeems[creatorContractAddress][instanceId];
 
         string memory prefix = "";
@@ -107,7 +112,9 @@ contract ERC1155BurnRedeem is BurnRedeemCore, IERC1155BurnRedeem {
      */
     function getBurnRedeemForToken(address creatorContractAddress, uint256 tokenId) external override view returns(uint256 instanceId, BurnRedeem memory burnRedeem) {
         instanceId = _redeemInstanceIds[creatorContractAddress][tokenId];
-        require(instanceId > 0, "Token does not exist");
+        if (instanceId == 0) {
+            revert InvalidToken(tokenId);
+        }
         burnRedeem = _burnRedeems[creatorContractAddress][instanceId];
     }
 
@@ -116,6 +123,8 @@ contract ERC1155BurnRedeem is BurnRedeemCore, IERC1155BurnRedeem {
      */
     function getBurnRedeemToken(address creatorContractAddress, uint256 instanceId) external override view returns(uint256 tokenId) {
         tokenId = _redeemTokenIds[creatorContractAddress][instanceId];
-        require(tokenId > 0, "Burn redeem does not exist");
+        if (tokenId == 0) {
+            revert BurnRedeemDoesNotExist(instanceId);
+        }
     }
 }

--- a/packages/manifold/contracts/burnredeem/IBurnRedeemCore.sol
+++ b/packages/manifold/contracts/burnredeem/IBurnRedeemCore.sol
@@ -12,6 +12,21 @@ import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
  * Burn Redeem Core interface
  */
 interface IBurnRedeemCore is IERC165, IERC721Receiver, IERC1155Receiver  {
+    error NotAdmin(address);
+    error UnsupportedContractVersion();
+    error InvalidToken(uint256);
+    error InvalidInput();
+    error InvalidData();
+    error TransferFailure();
+    
+    error BurnRedeemDoesNotExist(uint256);
+    error BurnRedeemInactive(uint256);
+
+    error InvalidBurnAmount();
+    error InvalidRedeemAmount();
+    error InvalidPaymentAmount();
+
+
     enum StorageProtocol { INVALID, NONE, ARWEAVE, IPFS }
 
     /**

--- a/packages/manifold/test/burnredeem1155.js
+++ b/packages/manifold/test/burnredeem1155.js
@@ -1,142 +1,145 @@
-const truffleAssert = require('truffle-assertions');
+const truffleAssert = require("truffle-assertions");
 const ERC1155BurnRedeem = artifacts.require("ERC1155BurnRedeem");
-const ERC721Creator = artifacts.require('@manifoldxyz/creator-core-extensions-solidity/ERC721Creator');
-const ERC1155Creator = artifacts.require('@manifoldxyz/creator-core-extensions-solidity/ERC1155Creator');
-const ethers = require('ethers');
-const MockManifoldMembership = artifacts.require('MockManifoldMembership');
+const ERC721Creator = artifacts.require("@manifoldxyz/creator-core-extensions-solidity/ERC721Creator");
+const ERC1155Creator = artifacts.require("@manifoldxyz/creator-core-extensions-solidity/ERC1155Creator");
+const ethers = require("ethers");
+const MockManifoldMembership = artifacts.require("MockManifoldMembership");
 
-const BURN_FEE = ethers.BigNumber.from('690000000000000');
+const BURN_FEE = ethers.BigNumber.from("690000000000000");
 
-contract('ERC1155BurnRedeem', function ([...accounts]) {
+contract("ERC1155BurnRedeem", function ([...accounts]) {
   const [owner, burnRedeemOwner, anyone1] = accounts;
-  describe('BurnRedeem', function () {
+  describe("BurnRedeem", function () {
     let creator, burnRedeem, burnable1155;
     beforeEach(async function () {
-      creator = await ERC1155Creator.new("Test", "TEST", {from:owner});
-      burnRedeem = await ERC1155BurnRedeem.new(burnRedeemOwner, {from:owner});
-      manifoldMembership = await MockManifoldMembership.new({from:owner});
-      await burnRedeem.setMembershipAddress(manifoldMembership.address, {from:burnRedeemOwner});
-      burnable1155 = await ERC1155Creator.new("Test", "TEST", {from:owner});
-      burnable1155_2 = await ERC1155Creator.new("Test", "TEST", {from:owner});
-      burnable721 = await ERC721Creator.new("Test", "TEST", {from:owner});
-      burnable721_2 = await ERC721Creator.new("Test", "TEST", {from:owner});
-      
+      creator = await ERC1155Creator.new("Test", "TEST", { from: owner });
+      burnRedeem = await ERC1155BurnRedeem.new(burnRedeemOwner, { from: owner });
+      manifoldMembership = await MockManifoldMembership.new({ from: owner });
+      await burnRedeem.setMembershipAddress(manifoldMembership.address, { from: burnRedeemOwner });
+      burnable1155 = await ERC1155Creator.new("Test", "TEST", { from: owner });
+      burnable1155_2 = await ERC1155Creator.new("Test", "TEST", { from: owner });
+      burnable721 = await ERC721Creator.new("Test", "TEST", { from: owner });
+      burnable721_2 = await ERC721Creator.new("Test", "TEST", { from: owner });
+
       // Must register with empty prefix in order to set per-token uri's
-      await creator.registerExtension(burnRedeem.address, {from:owner});
+      await creator.registerExtension(burnRedeem.address, { from: owner });
     });
 
-
-    it('access test', async function () {
-      let now = (await web3.eth.getBlock('latest')).timestamp-30; // seconds since unix epoch
+    it("access test", async function () {
+      let now = (await web3.eth.getBlock("latest")).timestamp - 30; // seconds since unix epoch
       let later = now + 1000;
 
       // Must be admin
-      await truffleAssert.reverts(burnRedeem.initializeBurnRedeem(
-        creator.address,
-        1,
-        {
-          startDate: now,
-          endDate: later,
-          redeemAmount: 1,
-          totalSupply: 10,
-          storageProtocol: 1,
-          location: "XXX",
-          cost: 0,
-          paymentReceiver: anyone1,
-          burnSet: []
-        },
-        {from:anyone1}
-      ), "Wallet is not an admin");
+      await truffleAssert.reverts(
+        burnRedeem.initializeBurnRedeem(
+          creator.address,
+          1,
+          {
+            startDate: now,
+            endDate: later,
+            redeemAmount: 1,
+            totalSupply: 10,
+            storageProtocol: 1,
+            location: "XXX",
+            cost: 0,
+            paymentReceiver: anyone1,
+            burnSet: [],
+          },
+          { from: anyone1 }
+        )
+      );
 
       // Succeeds because admin
-      await truffleAssert.passes(await burnRedeem.initializeBurnRedeem(
-        creator.address,
-        1,
-        {
-          startDate: now,
-          endDate: later,
-          redeemAmount: 1,
-          totalSupply: 10,
-          storageProtocol: 1,
-          location: "XXX",
-          cost: 0,
-          paymentReceiver: owner,
-          burnSet: []
-        },
-        {from:owner}
-      ));
+      await truffleAssert.passes(
+        await burnRedeem.initializeBurnRedeem(
+          creator.address,
+          1,
+          {
+            startDate: now,
+            endDate: later,
+            redeemAmount: 1,
+            totalSupply: 10,
+            storageProtocol: 1,
+            location: "XXX",
+            cost: 0,
+            paymentReceiver: owner,
+            burnSet: [],
+          },
+          { from: owner }
+        )
+      );
 
       // Fails because not admin
-      await truffleAssert.reverts(burnRedeem.updateBurnRedeem(
-        creator.address,
-        1,
-        {
-          startDate: now,
-          endDate: later,
-          redeemAmount: 1,
-          totalSupply: 10,
-          storageProtocol: 1,
-          location: "XXX",
-          cost: 0,
-          paymentReceiver: anyone1,
-          burnSet: []
-        },
-        {from:anyone1}
-      ), "Wallet is not an admin");
+      await truffleAssert.reverts(
+        burnRedeem.updateBurnRedeem(
+          creator.address,
+          1,
+          {
+            startDate: now,
+            endDate: later,
+            redeemAmount: 1,
+            totalSupply: 10,
+            storageProtocol: 1,
+            location: "XXX",
+            cost: 0,
+            paymentReceiver: anyone1,
+            burnSet: [],
+          },
+          { from: anyone1 }
+        )
+      );
 
       // Fails because not admin
-      await truffleAssert.reverts(burnRedeem.updateURI(
-        creator.address,
-        1,
-        1,
-        "",
-        {from:anyone1}
-      ), "Wallet is not an admin");
+      await truffleAssert.reverts(burnRedeem.updateURI(creator.address, 1, 1, "", { from: anyone1 }));
     });
 
-    it('initializeBurnRedeem input sanitization test', async function () {
-      let now = (await web3.eth.getBlock('latest')).timestamp-30; // seconds since unix epoch
+    it("initializeBurnRedeem input sanitization test", async function () {
+      let now = (await web3.eth.getBlock("latest")).timestamp - 30; // seconds since unix epoch
       let later = now + 1000;
 
       // Fails due to endDate <= startDate
-      await truffleAssert.reverts(burnRedeem.initializeBurnRedeem(
-        creator.address,
-        1,
-        {
-          startDate: now,
-          endDate: now,
-          redeemAmount: 1,
-          totalSupply: 10,
-          storageProtocol: 1,
-          location: "XXX",
-          cost: 0,
-          paymentReceiver: owner,
-          burnSet: []
-        },
-        {from:owner}
-      ), "startDate after endDate");
+      await truffleAssert.reverts(
+        burnRedeem.initializeBurnRedeem(
+          creator.address,
+          1,
+          {
+            startDate: now,
+            endDate: now,
+            redeemAmount: 1,
+            totalSupply: 10,
+            storageProtocol: 1,
+            location: "XXX",
+            cost: 0,
+            paymentReceiver: owner,
+            burnSet: [],
+          },
+          { from: owner }
+        )
+      );
 
       // Cannot update non-existant burn redeem
-      await truffleAssert.reverts(burnRedeem.updateBurnRedeem(
-        creator.address,
-        1,
-        {
-          startDate: now,
-          endDate: later,
-          redeemAmount: 1,
-          totalSupply: 10,
-          storageProtocol: 1,
-          location: "XXX",
-          cost: 0,
-          paymentReceiver: owner,
-          burnSet: []
-        },
-        {from:owner}
-      ), "Burn redeem not initialized");
+      await truffleAssert.reverts(
+        burnRedeem.updateBurnRedeem(
+          creator.address,
+          1,
+          {
+            startDate: now,
+            endDate: later,
+            redeemAmount: 1,
+            totalSupply: 10,
+            storageProtocol: 1,
+            location: "XXX",
+            cost: 0,
+            paymentReceiver: owner,
+            burnSet: [],
+          },
+          { from: owner }
+        )
+      );
     });
 
-    it('updateBurnRedeem input sanitization test', async function () {
-      let now = (await web3.eth.getBlock('latest')).timestamp-30; // seconds since unix epoch
+    it("updateBurnRedeem input sanitization test", async function () {
+      let now = (await web3.eth.getBlock("latest")).timestamp - 30; // seconds since unix epoch
       let later = now + 1000;
 
       await burnRedeem.initializeBurnRedeem(
@@ -151,50 +154,54 @@ contract('ERC1155BurnRedeem', function ([...accounts]) {
           location: "XXX",
           cost: 0,
           paymentReceiver: owner,
-          burnSet: []
+          burnSet: [],
         },
-        {from:owner}
+        { from: owner }
       );
-      
+
       // Fails due to non multiple of totalSupply
-      await truffleAssert.reverts(burnRedeem.updateBurnRedeem(
-        creator.address,
-        1,
-        {
-          startDate: now,
-          endDate: later,
-          redeemAmount: 3,
-          totalSupply: 10,
-          storageProtocol: 1,
-          location: "XXX",
-          cost: 0,
-          paymentReceiver: owner,
-          burnSet: []
-        },
-        {from:owner}
-      ), "Remainder left from totalSupply");
+      await truffleAssert.reverts(
+        burnRedeem.updateBurnRedeem(
+          creator.address,
+          1,
+          {
+            startDate: now,
+            endDate: later,
+            redeemAmount: 3,
+            totalSupply: 10,
+            storageProtocol: 1,
+            location: "XXX",
+            cost: 0,
+            paymentReceiver: owner,
+            burnSet: [],
+          },
+          { from: owner }
+        )
+      );
 
       // Fails due to endDate <= startDate
-      await truffleAssert.reverts(burnRedeem.updateBurnRedeem(
-        creator.address,
-        1,
-        {
-          startDate: now,
-          endDate: now,
-          redeemAmount: 1,
-          totalSupply: 10,
-          storageProtocol: 1,
-          location: "XXX",
-          cost: 0,
-          paymentReceiver: owner,
-          burnSet: []
-        },
-        {from:owner}
-      ), "startDate after endDate");
+      await truffleAssert.reverts(
+        burnRedeem.updateBurnRedeem(
+          creator.address,
+          1,
+          {
+            startDate: now,
+            endDate: now,
+            redeemAmount: 1,
+            totalSupply: 10,
+            storageProtocol: 1,
+            location: "XXX",
+            cost: 0,
+            paymentReceiver: owner,
+            burnSet: [],
+          },
+          { from: owner }
+        )
+      );
     });
 
-    it('tokenURI test', async function () {
-      let now = (await web3.eth.getBlock('latest')).timestamp-30; // seconds since unix epoch
+    it("tokenURI test", async function () {
+      let now = (await web3.eth.getBlock("latest")).timestamp - 30; // seconds since unix epoch
       let later = now + 1000;
 
       await burnRedeem.initializeBurnRedeem(
@@ -221,18 +228,18 @@ contract('ERC1155BurnRedeem', function ([...accounts]) {
                   amount: 1,
                   minTokenId: 0,
                   maxTokenId: 0,
-                  merkleRoot: ethers.utils.formatBytes32String("")
-                }
-              ]
-            }
+                  merkleRoot: ethers.utils.formatBytes32String(""),
+                },
+              ],
+            },
           ],
         },
-        {from:owner}
+        { from: owner }
       );
 
       // Mint burnable tokens
       await burnable1155.mintBaseNew([anyone1], [2], [""], { from: owner });
-      await burnable1155.setApprovalForAll(burnRedeem.address, true, {from:anyone1});
+      await burnable1155.setApprovalForAll(burnRedeem.address, true, { from: anyone1 });
 
       await burnRedeem.burnRedeem(
         creator.address,
@@ -244,22 +251,23 @@ contract('ERC1155BurnRedeem', function ([...accounts]) {
             itemIndex: 0,
             contractAddress: burnable1155.address,
             id: 1,
-            merkleProof: [ethers.utils.formatBytes32String("")]
+            merkleProof: [ethers.utils.formatBytes32String("")],
           },
         ],
-        {from:anyone1, value: BURN_FEE}
-      )
+        { from: anyone1, value: BURN_FEE }
+      );
 
-
-      assert.equal('XXX', await creator.uri(1));
+      assert.equal("XXX", await creator.uri(1));
     });
 
-    it('onERC1155Received test - multiple redemptions', async function() {
-
+    it("onERC1155Received test - multiple redemptions", async function () {
       // Test initializing a new burn redeem
-      let start = (await web3.eth.getBlock('latest')).timestamp-30; // seconds since unix epoch
+      let start = (await web3.eth.getBlock("latest")).timestamp - 30; // seconds since unix epoch
       let end = start + 300;
-      let burnRedeemData = web3.eth.abi.encodeParameters(["address", "uint256", "uint32", "uint256", "bytes32[]"], [creator.address, 1, 2, 0, []]);
+      let burnRedeemData = web3.eth.abi.encodeParameters(
+        ["address", "uint256", "uint32", "uint256", "bytes32[]"],
+        [creator.address, 1, 2, 0, []]
+      );
 
       // Mint burnable tokens
       await burnable1155.mintBaseNew([anyone1], [10], [""], { from: owner });
@@ -270,13 +278,7 @@ contract('ERC1155BurnRedeem', function ([...accounts]) {
       balance = await burnable1155.balanceOf(anyone1, 1);
       assert.equal(10, balance);
 
-      await truffleAssert.reverts(
-        burnRedeem.getBurnRedeemForToken(
-          creator.address,
-          1
-        ),
-        "Token does not exist"
-      )
+      await truffleAssert.reverts(burnRedeem.getBurnRedeemForToken(creator.address, 1));
 
       await burnRedeem.initializeBurnRedeem(
         creator.address,
@@ -302,26 +304,35 @@ contract('ERC1155BurnRedeem', function ([...accounts]) {
                   amount: 1,
                   minTokenId: 0,
                   maxTokenId: 0,
-                  merkleRoot: ethers.utils.formatBytes32String("")
-                }
-              ]
-            }
+                  merkleRoot: ethers.utils.formatBytes32String(""),
+                },
+              ],
+            },
           ],
         },
-        {from:owner}
+        { from: owner }
       );
 
       // Get burn redeem for token, should succeed
-      const burnRedeemInfo = await burnRedeem.getBurnRedeemForToken(creator.address, 1)
+      const burnRedeemInfo = await burnRedeem.getBurnRedeemForToken(creator.address, 1);
       assert.equal(burnRedeemInfo[0], 1);
       const burnRedeemForToken = burnRedeemInfo[1];
       assert.equal(burnRedeemForToken.contractVersion, 0);
 
       // Receiver functions require membership
-      await manifoldMembership.setMember(anyone1, true, {from:owner});
+      await manifoldMembership.setMember(anyone1, true, { from: owner });
 
       // Passes with value == 2 * burnItem.amount (2 redemptions)
-      await truffleAssert.passes(burnable1155.methods['safeTransferFrom(address,address,uint256,uint256,bytes)'](anyone1, burnRedeem.address, 1, 2, burnRedeemData, {from:anyone1}));
+      await truffleAssert.passes(
+        burnable1155.methods["safeTransferFrom(address,address,uint256,uint256,bytes)"](
+          anyone1,
+          burnRedeem.address,
+          1,
+          2,
+          burnRedeemData,
+          { from: anyone1 }
+        )
+      );
 
       // Ensure tokens are burned/minted
       balance = await burnable1155.balanceOf(anyone1, 1);
@@ -330,7 +341,16 @@ contract('ERC1155BurnRedeem', function ([...accounts]) {
       assert.equal(4, balance);
 
       // Passes with value == 2 * burnItem.amount (2 redemptions), but only 1 redemption left
-      await truffleAssert.passes(burnable1155.methods['safeTransferFrom(address,address,uint256,uint256,bytes)'](anyone1, burnRedeem.address, 1, 2, burnRedeemData, {from:anyone1}));
+      await truffleAssert.passes(
+        burnable1155.methods["safeTransferFrom(address,address,uint256,uint256,bytes)"](
+          anyone1,
+          burnRedeem.address,
+          1,
+          2,
+          burnRedeemData,
+          { from: anyone1 }
+        )
+      );
 
       // Ensure tokens are burned/returned/minted
       balance = await burnable1155.balanceOf(anyone1, 1);
@@ -340,7 +360,16 @@ contract('ERC1155BurnRedeem', function ([...accounts]) {
       assert.equal(6, balance);
 
       // Reverts with no redemptions left
-      await truffleAssert.reverts(burnable1155.methods['safeTransferFrom(address,address,uint256,uint256,bytes)'](anyone1, burnRedeem.address, 1, 1, burnRedeemData, {from:anyone1}), "No tokens available");
+      await truffleAssert.reverts(
+        burnable1155.methods["safeTransferFrom(address,address,uint256,uint256,bytes)"](
+          anyone1,
+          burnRedeem.address,
+          1,
+          1,
+          burnRedeemData,
+          { from: anyone1 }
+        )
+      );
     });
   });
 });


### PR DESCRIPTION
Reducing the B/R contract size to free up space for other features.

ERC1155BurnRedeem: 22.614 -> 21.12 KB
ERC721BurnRedeem: 24.451 -> 22.718 KB