### PR TITLE
feat: allow emitting arbitrary data alongside BurnRedeemMint event

### DIFF
--- a/packages/manifold/contracts/burnredeem/BurnRedeemCore.sol
+++ b/packages/manifold/contracts/burnredeem/BurnRedeemCore.sol
@@ -165,16 +165,6 @@ abstract contract BurnRedeemCore is ERC165, AdminControl, ReentrancyGuard, IBurn
     }
 
     /**
-     * See {IBurnRedeemCore-burnRedeem}.
-     */
-    function burnRedeem(address creatorContractAddress, uint256 instanceId, uint32 burnRedeemCount, BurnToken[] calldata burnTokens, bytes calldata data) external payable override nonReentrant {
-        uint256 payableCost = _burnRedeem(msg.value, creatorContractAddress, instanceId, burnRedeemCount, burnTokens, _isActiveMember(msg.sender), true, data);
-        if (msg.value > payableCost) {
-            _forwardValue(payable(msg.sender), msg.value - payableCost);
-        }
-    }
-
-    /**
      * (Batch overload) see {IBurnRedeemCore-burnRedeem}.
      */
     function burnRedeem(address[] calldata creatorContractAddresses, uint256[] calldata instanceIds, uint32[] calldata burnRedeemCounts, BurnToken[][] calldata burnTokens) external payable override nonReentrant {
@@ -193,6 +183,16 @@ abstract contract BurnRedeemCore is ERC165, AdminControl, ReentrancyGuard, IBurn
 
         if (msgValueRemaining != 0) {
             _forwardValue(payable(msg.sender), msgValueRemaining);
+        }
+    }
+
+    /**
+     * See {IBurnRedeemCore-burnRedeemWithData}.
+     */
+    function burnRedeemWithData(address creatorContractAddress, uint256 instanceId, uint32 burnRedeemCount, BurnToken[] calldata burnTokens, bytes calldata data) external payable override nonReentrant {
+        uint256 payableCost = _burnRedeem(msg.value, creatorContractAddress, instanceId, burnRedeemCount, burnTokens, _isActiveMember(msg.sender), true, data);
+        if (msg.value > payableCost) {
+            _forwardValue(payable(msg.sender), msg.value - payableCost);
         }
     }
 

--- a/packages/manifold/contracts/burnredeem/BurnRedeemLib.sol
+++ b/packages/manifold/contracts/burnredeem/BurnRedeemLib.sol
@@ -52,7 +52,7 @@ library BurnRedeemLib {
 
     event BurnRedeemInitialized(address indexed creatorContract, uint256 indexed instanceId, address initializer);
     event BurnRedeemUpdated(address indexed creatorContract, uint256 indexed instanceId);
-    event BurnRedeemMint(address indexed creatorContract, uint256 indexed instanceId, uint256 indexed tokenId, uint32 redeemedCount);
+    event BurnRedeemMint(address indexed creatorContract, uint256 indexed instanceId, uint256 indexed tokenId, uint32 redeemedCount, bytes data);
 
     error BurnRedeemAlreadyInitialized();
     error InvalidBurnItem();

--- a/packages/manifold/contracts/burnredeem/ERC1155BurnRedeem.sol
+++ b/packages/manifold/contracts/burnredeem/ERC1155BurnRedeem.sol
@@ -74,7 +74,7 @@ contract ERC1155BurnRedeem is BurnRedeemCore, IERC1155BurnRedeem {
     /**
      * Helper to mint multiple redeem tokens
      */
-    function _redeem(address creatorContractAddress, uint256 instanceId, BurnRedeem storage burnRedeemInstance, address to, uint32 count) internal override {
+    function _redeem(address creatorContractAddress, uint256 instanceId, BurnRedeem storage burnRedeemInstance, address to, uint32 count, bytes memory data) internal override {
         address[] memory addresses = new address[](1);
         addresses[0] = to;
         uint256[] memory tokenIds = new uint256[](1);
@@ -85,7 +85,7 @@ contract ERC1155BurnRedeem is BurnRedeemCore, IERC1155BurnRedeem {
         IERC1155CreatorCore(creatorContractAddress).mintExtensionExisting(addresses, tokenIds, values);
         burnRedeemInstance.redeemedCount += uint32(values[0]);
 
-        emit BurnRedeemLib.BurnRedeemMint(creatorContractAddress, instanceId, tokenIds[0], uint32(values[0]));
+        emit BurnRedeemLib.BurnRedeemMint(creatorContractAddress, instanceId, tokenIds[0], uint32(values[0]), data);
     }
 
     /**

--- a/packages/manifold/contracts/burnredeem/ERC721BurnRedeem.sol
+++ b/packages/manifold/contracts/burnredeem/ERC721BurnRedeem.sol
@@ -88,7 +88,7 @@ contract ERC721BurnRedeem is BurnRedeemCore, IERC721BurnRedeem {
     /** 
      * Helper to mint multiple redeem tokens
      */
-    function _redeem(address creatorContractAddress, uint256 instanceId, BurnRedeem storage burnRedeemInstance, address to, uint32 count) internal override {
+    function _redeem(address creatorContractAddress, uint256 instanceId, BurnRedeem storage burnRedeemInstance, address to, uint32 count, bytes memory data) internal override {
         if (burnRedeemInstance.redeemAmount == 1 && count == 1) {
             ++burnRedeemInstance.redeemedCount;
             uint256 newTokenId;
@@ -99,7 +99,7 @@ contract ERC721BurnRedeem is BurnRedeemCore, IERC721BurnRedeem {
                 newTokenId = IERC721CreatorCore(creatorContractAddress).mintExtension(to);
                 _redeemTokens[creatorContractAddress][newTokenId] = RedeemToken(uint224(instanceId), burnRedeemInstance.redeemedCount);
             }
-            emit BurnRedeemLib.BurnRedeemMint(creatorContractAddress, instanceId, newTokenId, 1);
+            emit BurnRedeemLib.BurnRedeemMint(creatorContractAddress, instanceId, newTokenId, 1, data);
         } else {
             uint256 totalCount = burnRedeemInstance.redeemAmount * count;
             if (totalCount > MAX_UINT_16) {
@@ -115,14 +115,14 @@ contract ERC721BurnRedeem is BurnRedeemCore, IERC721BurnRedeem {
                 }
                 uint256[] memory newTokenIds = IERC721CreatorCore(creatorContractAddress).mintExtensionBatch(to, tokenDatas);
                 for (uint256 i; i < totalCount;) {
-                    emit BurnRedeemLib.BurnRedeemMint(creatorContractAddress, instanceId, newTokenIds[i], 1);
+                    emit BurnRedeemLib.BurnRedeemMint(creatorContractAddress, instanceId, newTokenIds[i], 1, data);
                     unchecked { i++; }
                 }
             } else {
                 uint256[] memory newTokenIds = IERC721CreatorCore(creatorContractAddress).mintExtensionBatch(to, uint16(totalCount));
                 for (uint256 i; i < totalCount;) {
                     _redeemTokens[creatorContractAddress][newTokenIds[i]] = RedeemToken(uint224(instanceId), uint32(startingCount + i));
-                    emit BurnRedeemLib.BurnRedeemMint(creatorContractAddress, instanceId, newTokenIds[i], 1);
+                    emit BurnRedeemLib.BurnRedeemMint(creatorContractAddress, instanceId, newTokenIds[i], 1, data);
                     unchecked { i++; }
                 }
             }

--- a/packages/manifold/contracts/burnredeem/IBurnRedeemCore.sol
+++ b/packages/manifold/contracts/burnredeem/IBurnRedeemCore.sol
@@ -163,7 +163,7 @@ interface IBurnRedeemCore is IERC165, IERC721Receiver, IERC1155Receiver  {
      * @param instanceId                the instanceId of the burn redeem for the creator contract
      * @param burnRedeemCount           the number of burn redeems we want to do
      * @param burnTokens                the tokens to burn with pointers to the corresponding BurnItem requirement
-     * @param data                      the data to pass to the redeem callback
+     * @param data                      the data to emit with the BurnRedeemMint event
      */
     function burnRedeem(address creatorContractAddress, uint256 instanceId, uint32 burnRedeemCount, BurnToken[] calldata burnTokens, bytes calldata data) external payable;
 

--- a/packages/manifold/contracts/burnredeem/IBurnRedeemCore.sol
+++ b/packages/manifold/contracts/burnredeem/IBurnRedeemCore.sol
@@ -158,16 +158,6 @@ interface IBurnRedeemCore is IERC165, IERC721Receiver, IERC1155Receiver  {
     function burnRedeem(address creatorContractAddress, uint256 instanceId, uint32 burnRedeemCount, BurnToken[] calldata burnTokens) external payable;
 
     /**
-     * @notice burn tokens and mint a redeem token
-     * @param creatorContractAddress    the address of the creator contract
-     * @param instanceId                the instanceId of the burn redeem for the creator contract
-     * @param burnRedeemCount           the number of burn redeems we want to do
-     * @param burnTokens                the tokens to burn with pointers to the corresponding BurnItem requirement
-     * @param data                      the data to emit with the BurnRedeemMint event
-     */
-    function burnRedeem(address creatorContractAddress, uint256 instanceId, uint32 burnRedeemCount, BurnToken[] calldata burnTokens, bytes calldata data) external payable;
-
-    /**
      * @notice burn tokens and mint redeem tokens multiple times in a single transaction
      * @param creatorContractAddresses  the addresses of the creator contracts
      * @param instanceIds               the instanceIds of the burn redeems for the corresponding creator contract
@@ -175,6 +165,16 @@ interface IBurnRedeemCore is IERC165, IERC721Receiver, IERC1155Receiver  {
      * @param burnTokens                the tokens to burn for each burn redeem with pointers to the corresponding BurnItem requirement
      */
     function burnRedeem(address[] calldata creatorContractAddresses, uint256[] calldata instanceIds, uint32[] calldata burnRedeemCounts, BurnToken[][] calldata burnTokens) external payable;
+
+    /**
+     * @notice burn tokens and mint a redeem token
+     * @param creatorContractAddress    the address of the creator contract
+     * @param instanceId                the instanceId of the burn redeem for the creator contract
+     * @param burnRedeemCount           the number of burn redeems we want to do
+     * @param burnTokens                the tokens to burn with pointers to the corresponding BurnItem requirement
+     * @param data                      the data to emit with the BurnRedeemMint event
+     */
+    function burnRedeemWithData(address creatorContractAddress, uint256 instanceId, uint32 burnRedeemCount, BurnToken[] calldata burnTokens, bytes calldata data) external payable;
 
     /**
      * @notice allow admin to airdrop arbitrary tokens 

--- a/packages/manifold/contracts/burnredeem/IBurnRedeemCore.sol
+++ b/packages/manifold/contracts/burnredeem/IBurnRedeemCore.sol
@@ -158,6 +158,16 @@ interface IBurnRedeemCore is IERC165, IERC721Receiver, IERC1155Receiver  {
     function burnRedeem(address creatorContractAddress, uint256 instanceId, uint32 burnRedeemCount, BurnToken[] calldata burnTokens) external payable;
 
     /**
+     * @notice burn tokens and mint a redeem token
+     * @param creatorContractAddress    the address of the creator contract
+     * @param instanceId                the instanceId of the burn redeem for the creator contract
+     * @param burnRedeemCount           the number of burn redeems we want to do
+     * @param burnTokens                the tokens to burn with pointers to the corresponding BurnItem requirement
+     * @param data                      the data to pass to the redeem callback
+     */
+    function burnRedeem(address creatorContractAddress, uint256 instanceId, uint32 burnRedeemCount, BurnToken[] calldata burnTokens, bytes calldata data) external payable;
+
+    /**
      * @notice burn tokens and mint redeem tokens multiple times in a single transaction
      * @param creatorContractAddresses  the addresses of the creator contracts
      * @param instanceIds               the instanceIds of the burn redeems for the corresponding creator contract

--- a/packages/manifold/test/burnredeem721.js
+++ b/packages/manifold/test/burnredeem721.js
@@ -846,7 +846,7 @@ contract("ERC721BurnRedeem", function ([...accounts]) {
 
       await Promise.all(promises);
     });
-    it.only("redeem with custom data to be emitted", async function () {
+    it("redeem with custom data to be emitted", async function () {
       // Test initializing a new burn redeem
       let start = (await web3.eth.getBlock("latest")).timestamp - 30; // seconds since unix epoch
       let end = start + 300;

--- a/packages/manifold/test/burnredeem721.js
+++ b/packages/manifold/test/burnredeem721.js
@@ -846,6 +846,87 @@ contract("ERC721BurnRedeem", function ([...accounts]) {
 
       await Promise.all(promises);
     });
+    it.only("redeem with custom data to be emitted", async function () {
+      // Test initializing a new burn redeem
+      let start = (await web3.eth.getBlock("latest")).timestamp - 30; // seconds since unix epoch
+      let end = start + 300;
+
+      // Mint burnable tokens
+      for (let i = 0; i < 3; i++) {
+        await oz721.mint(anyone1, i + 1, { from: owner });
+      }
+
+      // Ensure that the creator contract state is what we expect before mints
+      let balance = await creator.balanceOf(anyone1);
+      assert.equal(0, balance);
+      balance = await oz721.balanceOf(anyone1);
+      assert.equal(3, balance);
+
+      await burnRedeem.initializeBurnRedeem(
+        creator.address,
+        1,
+        {
+          startDate: start,
+          endDate: end,
+          redeemAmount: 1,
+          totalSupply: 10,
+          storageProtocol: 1,
+          location: "XXX",
+          cost: 0,
+          paymentReceiver: owner,
+          burnSet: [
+            {
+              requiredCount: 1,
+              items: [
+                {
+                  validationType: 1,
+                  contractAddress: oz721.address,
+                  tokenSpec: 1,
+                  burnSpec: 0,
+                  amount: 0,
+                  minTokenId: 0,
+                  maxTokenId: 0,
+                  merkleRoot: ethers.utils.formatBytes32String(""),
+                },
+              ],
+            },
+          ],
+        },
+        false,
+        { from: owner }
+      );
+
+      // Set approvals
+      await oz721.setApprovalForAll(burnRedeem.address, true, { from: anyone1 });
+
+      const message = "hello";
+      // Passes
+      const tx = await burnRedeem.burnRedeem(
+        creator.address,
+        1,
+        1,
+        [
+          {
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: oz721.address,
+            id: 1,
+            merkleProof: [ethers.utils.formatBytes32String("")],
+          },
+        ],
+        ethers.utils.formatBytes32String(message),
+        { from: anyone1, value: BURN_FEE }
+      );
+
+      // Verify correct data was emitted
+      assert.equal(tx.receipt.logs[0].args.data, ethers.utils.formatBytes32String(message));
+
+      // Ensure tokens are burned/minted
+      balance = await oz721.balanceOf(anyone1);
+      assert.equal(2, balance);
+      balance = await creator.balanceOf(anyone1);
+      assert.equal(1, balance);
+    });
 
     it("burnRedeem test - contracts with fallbacks cant bypass burn requirements", async function () {
       let start = (await web3.eth.getBlock("latest")).timestamp - 30; // seconds since unix epoch

--- a/packages/manifold/test/burnredeem721.js
+++ b/packages/manifold/test/burnredeem721.js
@@ -901,7 +901,7 @@ contract("ERC721BurnRedeem", function ([...accounts]) {
 
       const message = "hello";
       // Passes
-      const tx = await burnRedeem.burnRedeem(
+      const tx = await burnRedeem.burnRedeemWithData(
         creator.address,
         1,
         1,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## This PR

Adds a new external call that allows passing through arbitrary data to the BurnRedeemMint event and safeTransferFrom to 0xdead. Mainly will be used by BTC ordinals community for ETH burns