### PR TITLE
fix: update burn anything to require off-chain burnSpec determination

### DIFF
--- a/packages/manifold/contracts/burnredeem/IBurnRedeemCore.sol
+++ b/packages/manifold/contracts/burnredeem/IBurnRedeemCore.sol
@@ -16,6 +16,8 @@ interface IBurnRedeemCore is IERC165, IERC721Receiver, IERC1155Receiver  {
     error UnsupportedContractVersion();
     error InvalidToken(uint256);
     error InvalidInput();
+    error InvalidTokenSpec();
+    error InvalidBurnSpec();
     error InvalidData();
     error TransferFailure();
     
@@ -39,7 +41,7 @@ interface IBurnRedeemCore is IERC165, IERC721Receiver, IERC1155Receiver  {
     enum ValidationType { INVALID, CONTRACT, RANGE, MERKLE_TREE, ANY }
 
     enum TokenSpec { INVALID, ERC721, ERC1155 }
-    enum BurnSpec { NONE, MANIFOLD, OPENZEPPELIN, UNKNOWN }
+    enum BurnSpec { NONE, MANIFOLD, OPENZEPPELIN }
 
     /**
      * @notice a `BurnItem` indicates which tokens are eligible to be burned

--- a/packages/manifold/test/burnredeem721.js
+++ b/packages/manifold/test/burnredeem721.js
@@ -696,23 +696,67 @@ contract("ERC721BurnRedeem", function ([...accounts]) {
             {
               requiredCount: 1,
               items: [
-                // ERC-721
+                // tokenSpec: ERC-721, burnSpec: NONE
                 {
                   validationType: 4,
                   contractAddress: "0x0000000000000000000000000000000000000000",
                   tokenSpec: 1,
-                  burnSpec: 3,
+                  burnSpec: 0,
                   amount: 0,
                   minTokenId: 0,
                   maxTokenId: 0,
                   merkleRoot: ethers.utils.formatBytes32String(""),
                 },
-                // ERC-1155
+                // tokenSpec: ERC-721, burnSpec: MANIFOLD
+                {
+                  validationType: 4,
+                  contractAddress: "0x0000000000000000000000000000000000000000",
+                  tokenSpec: 1,
+                  burnSpec: 1,
+                  amount: 0,
+                  minTokenId: 0,
+                  maxTokenId: 0,
+                  merkleRoot: ethers.utils.formatBytes32String(""),
+                },
+                // tokenSpec: ERC-721, burnSpec: OPENZEPPELIN
+                {
+                  validationType: 4,
+                  contractAddress: "0x0000000000000000000000000000000000000000",
+                  tokenSpec: 1,
+                  burnSpec: 2,
+                  amount: 0,
+                  minTokenId: 0,
+                  maxTokenId: 0,
+                  merkleRoot: ethers.utils.formatBytes32String(""),
+                },
+                // tokenSpec: ERC-1155, burnSpec: NONE
                 {
                   validationType: 4,
                   contractAddress: "0x0000000000000000000000000000000000000000",
                   tokenSpec: 2,
-                  burnSpec: 3,
+                  burnSpec: 0,
+                  amount: 1,
+                  minTokenId: 0,
+                  maxTokenId: 0,
+                  merkleRoot: ethers.utils.formatBytes32String(""),
+                },
+                // tokenSpec: ERC-1155, burnSpec: MANIFOLD
+                {
+                  validationType: 4,
+                  contractAddress: "0x0000000000000000000000000000000000000000",
+                  tokenSpec: 2,
+                  burnSpec: 1,
+                  amount: 1,
+                  minTokenId: 0,
+                  maxTokenId: 0,
+                  merkleRoot: ethers.utils.formatBytes32String(""),
+                },
+                // tokenSpec: ERC-1155, burnSpec: OPENZEPPELIN
+                {
+                  validationType: 4,
+                  contractAddress: "0x0000000000000000000000000000000000000000",
+                  tokenSpec: 2,
+                  burnSpec: 2,
                   amount: 1,
                   minTokenId: 0,
                   maxTokenId: 0,
@@ -729,15 +773,14 @@ contract("ERC721BurnRedeem", function ([...accounts]) {
       // Range of burnable options
       const burnContracts = [
         {
+          contract: oz721,
+          tokenSpec: 1,
+          mintTx: await oz721.mint(anyone1, 1, { from: owner }),
+        },
+        {
           contract: burnable721,
           tokenSpec: 1,
           mintTx: await burnable721.mintBase(anyone1, { from: owner }),
-          supportsBurn: true,
-        },
-        {
-          contract: burnable1155,
-          tokenSpec: 2,
-          mintTx: await burnable1155.mintBaseNew([anyone1], [10], [""], { from: owner }),
           supportsBurn: true,
         },
         {
@@ -747,35 +790,25 @@ contract("ERC721BurnRedeem", function ([...accounts]) {
           supportsBurn: true,
         },
         {
-          contract: oz1155Burnable,
-          tokenSpec: 2,
-          mintTx: await oz1155Burnable.mint(anyone1, 1, 1, { from: owner }),
-          supportsBurn: true,
-        },
-        {
-          contract: oz721,
-          tokenSpec: 1,
-          mintTx: await oz721.mint(anyone1, 1, { from: owner }),
-        },
-        {
           contract: oz1155,
           tokenSpec: 2,
           mintTx: await oz1155.mint(anyone1, 1, 1, { from: owner }),
         },
         {
-          contract: fallback1155,
+          contract: burnable1155,
           tokenSpec: 2,
-          mintTx: await fallback1155.mint(anyone1, 1, 1, { from: owner }),
+          mintTx: await burnable1155.mintBaseNew([anyone1], [10], [""], { from: owner }),
+          supportsBurn: true,
         },
         {
-          contract: fallback1155Burnable,
+          contract: oz1155Burnable,
           tokenSpec: 2,
-          mintTx: await fallback1155Burnable.mint(anyone1, 1, 1, { from: owner }),
+          mintTx: await oz1155Burnable.mint(anyone1, 1, 1, { from: owner }),
           supportsBurn: true,
         },
       ];
 
-      const promises = burnContracts.map(async ({ contract, tokenSpec, supportsBurn, hasFallback }) => {
+      const promises = burnContracts.map(async ({ contract, tokenSpec, supportsBurn }, i) => {
         await contract.setApprovalForAll(burnRedeem.address, true, { from: anyone1 });
 
         await truffleAssert.passes(
@@ -786,7 +819,7 @@ contract("ERC721BurnRedeem", function ([...accounts]) {
             [
               {
                 groupIndex: 0,
-                itemIndex: tokenSpec == 1 ? 0 : 1,
+                itemIndex: i,
                 contractAddress: contract.address,
                 id: 1,
                 merkleProof: [ethers.utils.formatBytes32String("")],
@@ -2575,7 +2608,7 @@ contract("ERC721BurnRedeem", function ([...accounts]) {
       assert.equal(1, balance);
     });
 
-    it.only("onERC1155Received test - multiple redemptions", async function () {
+    it("onERC1155Received test - multiple redemptions", async function () {
       // Test initializing a new burn redeem
       let start = (await web3.eth.getBlock("latest")).timestamp - 30; // seconds since unix epoch
       let end = start + 300;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Reverts back to the original plan of requiring off-chain burnSpec determination. When we were doing it on-chain, it resulted in internal execution reverts that shows a warning on Etherscan. Users will likely be confused when they see this so its better for us to optimize for that and just do more work on our backend. 

Example tx: https://goerli.etherscan.io/tx/0xd5714d5e803a0c875a48432737e02a8d36f26753720c2f9396198e3ea4d1447b

It's a bit ugly to initialize the burn redeem, but we should be able to clean all of this up if we want to refactor from the ground-up later (i'm pro pushing it to later as there's other features I want as well that can't be forced into this existing arch).
