### PR TITLE
Add ability to batch multiple frame mints into one transaction

### DIFF
--- a/packages/manifold/contracts/frameclaims/ERC1155FrameLazyClaim.sol
+++ b/packages/manifold/contracts/frameclaims/ERC1155FrameLazyClaim.sol
@@ -116,15 +116,18 @@ contract ERC1155FrameLazyClaim is IERC165, IERC1155FrameLazyClaim, ICreatorExten
     }
 
     /**
-     * See {ILazyPayableClaim-mint}.
+     * See {IFrameLazyClaim-mint}.
      */
-    function mint(address creatorContractAddress, uint256 instanceId, Recipient[] calldata recipients) external override {
-        Claim storage claim = _getClaim(creatorContractAddress, instanceId);
+    function mint(Mint[] calldata mints) external override {
         _validateMint();
-        // Do mint
-        _mintClaim(creatorContractAddress, claim, recipients);
+        for (uint256 i; i < mints.length;) {
+            Mint calldata mintData = mints[i];
+            Claim storage claim = _getClaim(mintData.creatorContractAddress, mintData.instanceId);
+            _mintClaim(mintData.creatorContractAddress, claim, mintData.recipients);
+            emit FrameClaimMint(mintData.creatorContractAddress, mintData.instanceId);
+            unchecked{ ++i; }
+        }
 
-        emit FrameClaimMint(creatorContractAddress, instanceId);
     }
 
     /**

--- a/packages/manifold/contracts/frameclaims/IFrameLazyClaim.sol
+++ b/packages/manifold/contracts/frameclaims/IFrameLazyClaim.sol
@@ -16,6 +16,12 @@ interface IFrameLazyClaim {
     event FrameClaimUpdated(address indexed creatorContract, uint256 indexed instanceId);
     event FrameClaimMint(address indexed creatorContract, uint256 indexed instanceId);
 
+    struct Mint {
+        address creatorContractAddress;
+        uint256 instanceId;
+        Recipient[] recipients;
+    }
+
     struct Recipient {
         address receiver;
         uint256 amount;
@@ -29,10 +35,8 @@ interface IFrameLazyClaim {
 
     /**
      * @notice allowlist minting based on signatures
-     * @param creatorContractAddress    the creator contract address
-     * @param instanceId                the claim instanceId for the creator contract
-     * @param recipients                the recipients to mint to
+     * @param mints    the mint instructions
      */
-    function mint(address creatorContractAddress, uint256 instanceId, Recipient[] calldata recipients) external;
+    function mint(Mint[] calldata mints) external;
 
 }


### PR DESCRIPTION
Add ability for frame lazy claims to be batched into one transaction for mutiple creator core instances.