### PR TITLE
Update README.md - Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # The Manifold Creator Core Extension Applications (Apps) Contracts
 
-**A library of examples Apps for use with [Manifold Creator Core](https://github.com/manifoldxyz/creator-core-solidity) contracts. Manifold Creator Core contracts can be deployed via [Manifold Studio](https://studo.manifold.xyz).**
+**A library of examples Apps for use with [Manifold Creator Core](https://github.com/manifoldxyz/creator-core-solidity) contracts. Manifold Creator Core contracts can be deployed via [Manifold Studio](https://studio.manifold.xyz).**
 
 This repo contains reference implementations and examples for apps that you can add to any Manifold Creator Core contract.  Examples are split up into package groupings.  See each package for details.


### PR DESCRIPTION
Fix typo in Manifold Studio link

<!--- Provide a general summary of your changes in the Title above -->

The Manifold Studio link in the readme has a typo.

<!-- Please give us a rough overview of the PR's changes here. -->

The typo is fixed, and the link works.


### Ticket

N/A

## CR Notes

N/A

## QA Steps

N/A
