### PR TITLE
LazyClaim Enhancements

### DIFF
--- a/packages/manifold/contracts/lazyclaim/ERC1155LazyPayableClaim.sol
+++ b/packages/manifold/contracts/lazyclaim/ERC1155LazyPayableClaim.sol
@@ -9,6 +9,7 @@ import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 import "./LazyPayableClaim.sol";
 import "./IERC1155LazyPayableClaim.sol";
+import "./IERC1155LazyPayableClaimMetadata.sol";
 
 /**
  * @title Lazy Payable Claim
@@ -47,8 +48,9 @@ contract ERC1155LazyPayableClaim is IERC165, IERC1155LazyPayableClaim, ICreatorE
         require(_claims[creatorContractAddress][instanceId].storageProtocol == StorageProtocol.INVALID, "Claim already initialized");
 
         // Sanity checks
-        require(claimParameters.storageProtocol != StorageProtocol.INVALID, "Cannot initialize with invalid storage protocol");
-        require(claimParameters.endDate == 0 || claimParameters.startDate < claimParameters.endDate, "Cannot have startDate greater than or equal to endDate");
+        if (claimParameters.storageProtocol == StorageProtocol.INVALID) revert ILazyPayableClaim.InvalidStorageProtocol();
+        if (claimParameters.storageProtocol == StorageProtocol.ADDRESS && claimParameters.location.length != 20) revert ILazyPayableClaim.InvalidStorageProtocol();
+        if (claimParameters.endDate != 0 && claimParameters.startDate >= claimParameters.endDate) revert ILazyPayableClaim.InvalidStartDate();
         require(claimParameters.merkleRoot == "" || claimParameters.walletMax == 0, "Cannot provide both walletMax and merkleRoot");
 
         address[] memory receivers = new address[](1);
@@ -87,9 +89,10 @@ contract ERC1155LazyPayableClaim is IERC165, IERC1155LazyPayableClaim, ICreatorE
         ClaimParameters memory claimParameters
     ) external override creatorAdminRequired(creatorContractAddress) {
         Claim memory claim = _getClaim(creatorContractAddress, instanceId);
-        require(claimParameters.storageProtocol != StorageProtocol.INVALID, "Cannot set invalid storage protocol");
-        require(claimParameters.endDate == 0 || claimParameters.startDate < claimParameters.endDate, "Cannot have startDate greater than or equal to endDate");
-        require(claimParameters.erc20 == claim.erc20, "Cannot change payment token");
+        if (claimParameters.storageProtocol == StorageProtocol.INVALID) revert ILazyPayableClaim.InvalidStorageProtocol();
+        if (claimParameters.storageProtocol == StorageProtocol.ADDRESS && claimParameters.location.length != 20) revert ILazyPayableClaim.InvalidStorageProtocol();
+        if (claimParameters.endDate != 0 && claimParameters.startDate >= claimParameters.endDate) revert ILazyPayableClaim.InvalidStartDate();
+        if (claimParameters.erc20 != claim.erc20) revert ILazyPayableClaim.CannotChangePaymentToken();
         if (claimParameters.totalMax != 0 && claim.total > claimParameters.totalMax) {
             claimParameters.totalMax = claim.total;
         }
@@ -119,10 +122,11 @@ contract ERC1155LazyPayableClaim is IERC165, IERC1155LazyPayableClaim, ICreatorE
     function updateTokenURIParams(
         address creatorContractAddress, uint256 instanceId,
         StorageProtocol storageProtocol,
-        string calldata location
+        bytes calldata location
     ) external override creatorAdminRequired(creatorContractAddress) {
         Claim storage claim = _getClaim(creatorContractAddress, instanceId);
-        require(storageProtocol != StorageProtocol.INVALID, "Cannot set invalid storage protocol");
+        if (storageProtocol == StorageProtocol.INVALID) revert ILazyPayableClaim.InvalidStorageProtocol();
+        if (storageProtocol == StorageProtocol.ADDRESS && location.length != 20) revert ILazyPayableClaim.InvalidStorageProtocol();
 
         claim.storageProtocol = storageProtocol;
         claim.location = location;
@@ -134,11 +138,11 @@ contract ERC1155LazyPayableClaim is IERC165, IERC1155LazyPayableClaim, ICreatorE
      */
     function extendTokenURI(
         address creatorContractAddress, uint256 instanceId,
-        string calldata locationChunk
+        bytes calldata locationChunk
     ) external override creatorAdminRequired(creatorContractAddress) {
         Claim storage claim = _getClaim(creatorContractAddress, instanceId);
-        require(claim.storageProtocol == StorageProtocol.NONE, "Invalid storage protocol");
-        claim.location = string(abi.encodePacked(claim.location, locationChunk));
+        if (claim.storageProtocol != StorageProtocol.NONE) revert ILazyPayableClaim.InvalidStorageProtocol();
+        claim.location = abi.encodePacked(claim.location, locationChunk);
     }
 
     /**
@@ -158,7 +162,7 @@ contract ERC1155LazyPayableClaim is IERC165, IERC1155LazyPayableClaim, ICreatorE
 
     function _getClaim(address creatorContractAddress, uint256 instanceId) private view returns(Claim storage claim) {
         claim = _claims[creatorContractAddress][instanceId];
-        require(claim.storageProtocol != StorageProtocol.INVALID, "Claim not initialized");
+        if (claim.storageProtocol == StorageProtocol.INVALID) revert ILazyPayableClaim.ClaimNotInitialized();
     }
 
     /**
@@ -198,7 +202,7 @@ contract ERC1155LazyPayableClaim is IERC165, IERC1155LazyPayableClaim, ICreatorE
 
         if (claim.signingAddress != address(0)) revert MustUseSignatureMinting();
         // Check totalMax
-        require(++claim.total <= claim.totalMax || claim.totalMax == 0, "Maximum tokens already minted for this claim");
+        if (((++claim.total > claim.totalMax && claim.totalMax != 0) || claim.total > MAX_UINT_24)) revert ILazyPayableClaim.TooManyRequested();
 
         // Validate mint
         _validateMint(creatorContractAddress, instanceId, claim.startDate, claim.endDate, claim.walletMax, claim.merkleRoot, mintIndex, merkleProof, mintFor);
@@ -222,10 +226,10 @@ contract ERC1155LazyPayableClaim is IERC165, IERC1155LazyPayableClaim, ICreatorE
     function mintBatch(address creatorContractAddress, uint256 instanceId, uint16 mintCount, uint32[] calldata mintIndices, bytes32[][] calldata merkleProofs, address mintFor) external payable override {
         Claim storage claim = _getClaim(creatorContractAddress, instanceId);
 
-        if (claim.signingAddress != address(0)) revert MustUseSignatureMinting();
+        if (claim.signingAddress != address(0)) revert ILazyPayableClaim.MustUseSignatureMinting();
         // Check totalMax
         claim.total += mintCount;
-        if ((claim.totalMax != 0 && claim.total > claim.totalMax)) revert TooManyRequested();
+        if ((claim.totalMax != 0 && claim.total > claim.totalMax)) revert ILazyPayableClaim.TooManyRequested();
 
         // Validate mint
         _validateMint(creatorContractAddress, instanceId, claim.startDate, claim.endDate, claim.walletMax, claim.merkleRoot, mintCount, mintIndices, merkleProofs, mintFor);
@@ -249,10 +253,10 @@ contract ERC1155LazyPayableClaim is IERC165, IERC1155LazyPayableClaim, ICreatorE
     function mintProxy(address creatorContractAddress, uint256 instanceId, uint16 mintCount, uint32[] calldata mintIndices, bytes32[][] calldata merkleProofs, address mintFor) external payable override {
         Claim storage claim = _getClaim(creatorContractAddress, instanceId);
 
-        if (claim.signingAddress != address(0)) revert MustUseSignatureMinting();
+        if (claim.signingAddress != address(0)) revert ILazyPayableClaim.MustUseSignatureMinting();
         // Check totalMax
         claim.total += mintCount;
-        if ((claim.totalMax != 0 && claim.total > claim.totalMax)) revert TooManyRequested();
+        if ((claim.totalMax != 0 && claim.total > claim.totalMax)) revert ILazyPayableClaim.TooManyRequested();
 
         // Validate mint
         _validateMintProxy(creatorContractAddress, instanceId, claim.startDate, claim.endDate, claim.walletMax, claim.merkleRoot, mintCount, mintIndices, merkleProofs, mintFor);
@@ -280,7 +284,7 @@ contract ERC1155LazyPayableClaim is IERC165, IERC1155LazyPayableClaim, ICreatorE
 
         // Check totalMax
         claim.total += mintCount;
-        if ((claim.totalMax != 0 && claim.total > claim.totalMax)) revert TooManyRequested();
+        if ((claim.totalMax != 0 && claim.total > claim.totalMax)) revert ILazyPayableClaim.TooManyRequested();
         // Validate mint
         _validateMintSignature(claim.startDate, claim.endDate, signature, claim.signingAddress);
         _checkSignatureAndUpdate(creatorContractAddress, instanceId, signature, message, nonce, claim.signingAddress, mintFor, expiration, mintCount);
@@ -303,7 +307,7 @@ contract ERC1155LazyPayableClaim is IERC165, IERC1155LazyPayableClaim, ICreatorE
      */
     function airdrop(address creatorContractAddress, uint256 instanceId, address[] calldata recipients,
         uint256[] calldata amounts) external override creatorAdminRequired(creatorContractAddress) {
-        require(recipients.length == amounts.length, "Unequal number of recipients and amounts provided");
+        if (recipients.length != amounts.length) revert ILazyPayableClaim.InvalidAirdrop();
 
         // Fetch the claim
         Claim storage claim = _getClaim(creatorContractAddress, instanceId);
@@ -336,9 +340,13 @@ contract ERC1155LazyPayableClaim is IERC165, IERC1155LazyPayableClaim, ICreatorE
      * See {ICreatorExtensionTokenURI-tokenURI}.
      */
     function tokenURI(address creatorContractAddress, uint256 tokenId) external override view returns(string memory uri) {
-        uint224 tokenClaim = uint224(_claimTokenIds[creatorContractAddress][tokenId]);
-        require(tokenClaim > 0, "Token does not exist");
-        Claim memory claim = _claims[creatorContractAddress][tokenClaim];
+        uint224 instanceId = uint224(_claimTokenIds[creatorContractAddress][tokenId]);
+        if (instanceId == 0) revert ILazyPayableClaim.TokenDNE();
+        Claim memory claim = _claims[creatorContractAddress][instanceId];
+
+        if (claim.storageProtocol == StorageProtocol.ADDRESS) {
+            return IERC1155LazyPayableClaimMetadata(_bytesToAddress(claim.location)).tokenURI(creatorContractAddress, tokenId, instanceId);
+        }
 
         string memory prefix = "";
         if (claim.storageProtocol == StorageProtocol.ARWEAVE) {

--- a/packages/manifold/contracts/lazyclaim/IERC1155LazyPayableClaim.sol
+++ b/packages/manifold/contracts/lazyclaim/IERC1155LazyPayableClaim.sol
@@ -18,7 +18,7 @@ interface IERC1155LazyPayableClaim is ILazyPayableClaim {
         uint48 endDate;
         StorageProtocol storageProtocol;
         bytes32 merkleRoot;
-        string location;
+        bytes location;
         uint256 cost;
         address payable paymentReceiver;
         address erc20;
@@ -33,7 +33,7 @@ interface IERC1155LazyPayableClaim is ILazyPayableClaim {
         uint48 endDate;
         StorageProtocol storageProtocol;
         bytes32 merkleRoot;
-        string location;
+        bytes location;
         uint256 tokenId;
         uint256 cost;
         address payable paymentReceiver;
@@ -64,7 +64,7 @@ interface IERC1155LazyPayableClaim is ILazyPayableClaim {
      * @param storageProtocol           the new storage protocol
      * @param location                  the new location
      */
-    function updateTokenURIParams(address creatorContractAddress, uint256 instanceId, StorageProtocol storageProtocol, string calldata location) external;
+    function updateTokenURIParams(address creatorContractAddress, uint256 instanceId, StorageProtocol storageProtocol, bytes calldata location) external;
 
     /**
      * @notice extend tokenURI parameters for an existing claim at instanceId.  Must have NONE StorageProtocol
@@ -72,7 +72,7 @@ interface IERC1155LazyPayableClaim is ILazyPayableClaim {
      * @param instanceId                the claim instanceId for the creator contract
      * @param locationChunk             the additional location chunk
      */
-    function extendTokenURI(address creatorContractAddress, uint256 instanceId, string calldata locationChunk) external;
+    function extendTokenURI(address creatorContractAddress, uint256 instanceId, bytes calldata locationChunk) external;
 
     /**
      * @notice get a claim corresponding to a creator contract and instanceId

--- a/packages/manifold/contracts/lazyclaim/IERC1155LazyPayableClaimMetadata.sol
+++ b/packages/manifold/contracts/lazyclaim/IERC1155LazyPayableClaimMetadata.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/// @author: manifold.xyz
+
+/**
+ * ERC1155 Lazy Payable Claim External Metadata interface
+ */
+interface IERC1155LazyPayableClaimMetadata {
+    /**
+     * @notice Get the token URI for a claim instance
+     */
+    function tokenURI(address creatorContract, uint256 tokenId, uint256 instanceId) external view returns (string memory);
+}

--- a/packages/manifold/contracts/lazyclaim/IERC721LazyPayableClaim.sol
+++ b/packages/manifold/contracts/lazyclaim/IERC721LazyPayableClaim.sol
@@ -18,7 +18,7 @@ interface IERC721LazyPayableClaim is ILazyPayableClaim {
         StorageProtocol storageProtocol;
         bool identical;
         bytes32 merkleRoot;
-        string location;
+        bytes location;
         uint256 cost;
         address payable paymentReceiver;
         address erc20;
@@ -35,7 +35,7 @@ interface IERC721LazyPayableClaim is ILazyPayableClaim {
         uint8 contractVersion;
         bool identical;
         bytes32 merkleRoot;
-        string location;
+        bytes location;
         uint256 cost;
         address payable paymentReceiver;
         address erc20;
@@ -66,7 +66,7 @@ interface IERC721LazyPayableClaim is ILazyPayableClaim {
      * @param identical                 the new value of identical
      * @param location                  the new location
      */
-    function updateTokenURIParams(address creatorContractAddress, uint256 instanceId, StorageProtocol storageProtocol, bool identical, string calldata location) external;
+    function updateTokenURIParams(address creatorContractAddress, uint256 instanceId, StorageProtocol storageProtocol, bool identical, bytes calldata location) external;
 
     /**
      * @notice extend tokenURI parameters for an existing claim at instanceId.  Must have NONE StorageProtocol
@@ -74,7 +74,7 @@ interface IERC721LazyPayableClaim is ILazyPayableClaim {
      * @param instanceId                the claim instanceId for the creator contract
      * @param locationChunk             the additional location chunk
      */
-    function extendTokenURI(address creatorContractAddress, uint256 instanceId, string calldata locationChunk) external;
+    function extendTokenURI(address creatorContractAddress, uint256 instanceId, bytes calldata locationChunk) external;
 
     /**
      * @notice get a claim corresponding to a creator contract and instanceId

--- a/packages/manifold/contracts/lazyclaim/IERC721LazyPayableClaimMetadata.sol
+++ b/packages/manifold/contracts/lazyclaim/IERC721LazyPayableClaimMetadata.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/// @author: manifold.xyz
+
+/**
+ * ERC721 Lazy Payable Claim External Metadata interface
+ */
+interface IERC721LazyPayableClaimMetadata {
+    /**
+     * @notice Get the token URI for a claim instance
+     */
+    function tokenURI(address creatorContract, uint256 tokenId, uint256 instanceId, uint24 mintOrder) external view returns (string memory);
+}

--- a/packages/manifold/contracts/lazyclaim/ILazyPayableClaim.sol
+++ b/packages/manifold/contracts/lazyclaim/ILazyPayableClaim.sol
@@ -8,7 +8,22 @@ pragma solidity ^0.8.0;
  * Lazy Payable Claim interface
  */
 interface ILazyPayableClaim {
-    enum StorageProtocol { INVALID, NONE, ARWEAVE, IPFS }
+    error InvalidStorageProtocol();
+    error ClaimNotInitialized();
+    error InvalidStartDate();
+    error InvalidAirdrop();
+    error TokenDNE();
+    error InvalidInstance();
+    error InvalidInput();
+    error ClaimInactive();
+    error TooManyRequested();
+    error MustUseSignatureMinting();
+    error FailedToTransfer();
+    error InvalidSignature();
+    error ExpiredSignature();
+    error CannotChangePaymentToken();
+
+    enum StorageProtocol { INVALID, NONE, ARWEAVE, IPFS, ADDRESS }
     
     event ClaimInitialized(address indexed creatorContract, uint256 indexed instanceId, address initializer);
     event ClaimUpdated(address indexed creatorContract, uint256 indexed instanceId);

--- a/packages/manifold/test/lazyclaim/ERC1155LazyPayableClaimSignatureMinting.t.sol
+++ b/packages/manifold/test/lazyclaim/ERC1155LazyPayableClaimSignatureMinting.t.sol
@@ -162,7 +162,7 @@ contract ERC1155LazyPayableClaimSignatureMintingTest is Test {
       (v, r, s) = vm.sign(privateKey, message);
       signature = abi.encodePacked(r, s, v);
 
-      vm.expectRevert(InvalidSignature.selector);
+      vm.expectRevert(ILazyPayableClaim.InvalidSignature.selector);
       example.mintSignature{value: mintFee*3}(
         address(creatorCore),
         1,
@@ -180,7 +180,7 @@ contract ERC1155LazyPayableClaimSignatureMintingTest is Test {
       message = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", address(creatorCore), uint256(1), nonce, other2, expiration, mintCount));
       (v, r, s) = vm.sign(privateKey2, message);
       signature = abi.encodePacked(r, s, v);
-      vm.expectRevert(InvalidSignature.selector);
+      vm.expectRevert(ILazyPayableClaim.InvalidSignature.selector);
       example.mintSignature{value: mintFee*3}(
         address(creatorCore),
         1,
@@ -198,7 +198,7 @@ contract ERC1155LazyPayableClaimSignatureMintingTest is Test {
       message = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", address(creatorCore), uint256(1), nonce, other2, expiration, mintCount));
       (v, r, s) = vm.sign(privateKey, message);
       signature = abi.encodePacked(r, s, v);
-      vm.expectRevert(ExpiredSignature.selector);
+      vm.expectRevert(ILazyPayableClaim.ExpiredSignature.selector);
       example.mintSignature{value: mintFee*3}(
         address(creatorCore),
         1,
@@ -214,13 +214,13 @@ contract ERC1155LazyPayableClaimSignatureMintingTest is Test {
       assertEq(3, creatorCore.balanceOf(other2, 1));
 
       // Cannot mint other ways when signature is non-zero
-      vm.expectRevert(MustUseSignatureMinting.selector);
+      vm.expectRevert(ILazyPayableClaim.MustUseSignatureMinting.selector);
       example.mint{ value: mintFee * 3 }(address(creatorCore), 1, uint16(3), new bytes32[](0), other);
 
-      vm.expectRevert(MustUseSignatureMinting.selector);
+      vm.expectRevert(ILazyPayableClaim.MustUseSignatureMinting.selector);
       example.mintBatch{value:mintFee*3}(address(creatorCore), 1, 3, new uint32[](0), new bytes32[][](0), other);
 
-      vm.expectRevert(MustUseSignatureMinting.selector);
+      vm.expectRevert(ILazyPayableClaim.MustUseSignatureMinting.selector);
       example.mintProxy{value:mintFee*3}(address(creatorCore), 1, 3, new uint32[](0), new bytes32[][](0), other);
 
       // Other owns none because all mints with other methods failed
@@ -242,7 +242,7 @@ contract ERC1155LazyPayableClaimSignatureMintingTest is Test {
       message = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", address(creatorCore), uint256(1), nonce, other2, expiration, mintCount));
       (v, r, s) = vm.sign(privateKey, message);
       signature = abi.encodePacked(r, s, v);
-      vm.expectRevert(MustUseSignatureMinting.selector);
+      vm.expectRevert(ILazyPayableClaim.MustUseSignatureMinting.selector);
       example.mintSignature{value: mintFee*3}(
         address(creatorCore),
         1,

--- a/packages/manifold/test/lazyclaim/ERC721LazyPayableClaimSignatureMinting.t.sol
+++ b/packages/manifold/test/lazyclaim/ERC721LazyPayableClaimSignatureMinting.t.sol
@@ -163,7 +163,7 @@ contract ERC721LazyPayableClaimSignatureMintingTest is Test {
       (v, r, s) = vm.sign(privateKey, message);
       signature = abi.encodePacked(r, s, v);
 
-      vm.expectRevert(InvalidSignature.selector);
+      vm.expectRevert(ILazyPayableClaim.InvalidSignature.selector);
       example.mintSignature{value: mintFee*3}(
         address(creatorCore),
         1,
@@ -181,7 +181,7 @@ contract ERC721LazyPayableClaimSignatureMintingTest is Test {
       message = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", address(creatorCore), uint256(1), nonce, other2, expiration, mintCount));
       (v, r, s) = vm.sign(privateKey2, message);
       signature = abi.encodePacked(r, s, v);
-      vm.expectRevert(InvalidSignature.selector);
+      vm.expectRevert(ILazyPayableClaim.InvalidSignature.selector);
       example.mintSignature{value: mintFee*3}(
         address(creatorCore),
         1,
@@ -199,7 +199,7 @@ contract ERC721LazyPayableClaimSignatureMintingTest is Test {
       message = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", address(creatorCore), uint256(1), nonce, other2, expiration, mintCount));
       (v, r, s) = vm.sign(privateKey, message);
       signature = abi.encodePacked(r, s, v);
-      vm.expectRevert(ExpiredSignature.selector);
+      vm.expectRevert(ILazyPayableClaim.ExpiredSignature.selector);
       example.mintSignature{value: mintFee*3}(
         address(creatorCore),
         1,
@@ -215,13 +215,13 @@ contract ERC721LazyPayableClaimSignatureMintingTest is Test {
       assertEq(3, creatorCore.balanceOf(other2));
 
       // Cannot mint other ways when signature is non-zero
-      vm.expectRevert(MustUseSignatureMinting.selector);
+      vm.expectRevert(ILazyPayableClaim.MustUseSignatureMinting.selector);
       example.mint{ value: mintFee * 3 }(address(creatorCore), 1, uint16(3), new bytes32[](0), other);
 
-      vm.expectRevert(MustUseSignatureMinting.selector);
+      vm.expectRevert(ILazyPayableClaim.MustUseSignatureMinting.selector);
       example.mintBatch{value:mintFee*3}(address(creatorCore), 1, 3, new uint32[](0), new bytes32[][](0), other);
 
-      vm.expectRevert(MustUseSignatureMinting.selector);
+      vm.expectRevert(ILazyPayableClaim.MustUseSignatureMinting.selector);
       example.mintProxy{value:mintFee*3}(address(creatorCore), 1, 3, new uint32[](0), new bytes32[][](0), other);
 
       // Other owns none because all mints with other methods failed
@@ -243,7 +243,7 @@ contract ERC721LazyPayableClaimSignatureMintingTest is Test {
       message = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", address(creatorCore), uint256(1), nonce, other2, expiration, mintCount));
       (v, r, s) = vm.sign(privateKey, message);
       signature = abi.encodePacked(r, s, v);
-      vm.expectRevert(MustUseSignatureMinting.selector);
+      vm.expectRevert(ILazyPayableClaim.MustUseSignatureMinting.selector);
       example.mintSignature{value: mintFee*3}(
         address(creatorCore),
         1,


### PR DESCRIPTION
 Convert revert strings to error codes. Add external contract support for token metadata
