### PR TITLE
use string location, even for address references

### DIFF
--- a/packages/manifold/contracts/lazyclaim/ERC1155LazyPayableClaim.sol
+++ b/packages/manifold/contracts/lazyclaim/ERC1155LazyPayableClaim.sol
@@ -49,7 +49,7 @@ contract ERC1155LazyPayableClaim is IERC165, IERC1155LazyPayableClaim, ICreatorE
 
         // Sanity checks
         if (claimParameters.storageProtocol == StorageProtocol.INVALID) revert ILazyPayableClaim.InvalidStorageProtocol();
-        if (claimParameters.storageProtocol == StorageProtocol.ADDRESS && claimParameters.location.length != 20) revert ILazyPayableClaim.InvalidStorageProtocol();
+        if (claimParameters.storageProtocol == StorageProtocol.ADDRESS && bytes(claimParameters.location).length != 20) revert ILazyPayableClaim.InvalidStorageProtocol();
         if (claimParameters.endDate != 0 && claimParameters.startDate >= claimParameters.endDate) revert ILazyPayableClaim.InvalidStartDate();
         require(claimParameters.merkleRoot == "" || claimParameters.walletMax == 0, "Cannot provide both walletMax and merkleRoot");
 
@@ -90,7 +90,7 @@ contract ERC1155LazyPayableClaim is IERC165, IERC1155LazyPayableClaim, ICreatorE
     ) external override creatorAdminRequired(creatorContractAddress) {
         Claim memory claim = _getClaim(creatorContractAddress, instanceId);
         if (claimParameters.storageProtocol == StorageProtocol.INVALID) revert ILazyPayableClaim.InvalidStorageProtocol();
-        if (claimParameters.storageProtocol == StorageProtocol.ADDRESS && claimParameters.location.length != 20) revert ILazyPayableClaim.InvalidStorageProtocol();
+        if (claimParameters.storageProtocol == StorageProtocol.ADDRESS && bytes(claimParameters.location).length != 20) revert ILazyPayableClaim.InvalidStorageProtocol();
         if (claimParameters.endDate != 0 && claimParameters.startDate >= claimParameters.endDate) revert ILazyPayableClaim.InvalidStartDate();
         if (claimParameters.erc20 != claim.erc20) revert ILazyPayableClaim.CannotChangePaymentToken();
         if (claimParameters.totalMax != 0 && claim.total > claimParameters.totalMax) {
@@ -122,11 +122,11 @@ contract ERC1155LazyPayableClaim is IERC165, IERC1155LazyPayableClaim, ICreatorE
     function updateTokenURIParams(
         address creatorContractAddress, uint256 instanceId,
         StorageProtocol storageProtocol,
-        bytes calldata location
+        string calldata location
     ) external override creatorAdminRequired(creatorContractAddress) {
         Claim storage claim = _getClaim(creatorContractAddress, instanceId);
         if (storageProtocol == StorageProtocol.INVALID) revert ILazyPayableClaim.InvalidStorageProtocol();
-        if (storageProtocol == StorageProtocol.ADDRESS && location.length != 20) revert ILazyPayableClaim.InvalidStorageProtocol();
+        if (storageProtocol == StorageProtocol.ADDRESS && bytes(location).length != 20) revert ILazyPayableClaim.InvalidStorageProtocol();
 
         claim.storageProtocol = storageProtocol;
         claim.location = location;
@@ -138,11 +138,11 @@ contract ERC1155LazyPayableClaim is IERC165, IERC1155LazyPayableClaim, ICreatorE
      */
     function extendTokenURI(
         address creatorContractAddress, uint256 instanceId,
-        bytes calldata locationChunk
+        string calldata locationChunk
     ) external override creatorAdminRequired(creatorContractAddress) {
         Claim storage claim = _getClaim(creatorContractAddress, instanceId);
         if (claim.storageProtocol != StorageProtocol.NONE) revert ILazyPayableClaim.InvalidStorageProtocol();
-        claim.location = abi.encodePacked(claim.location, locationChunk);
+        claim.location = string(abi.encodePacked(claim.location, locationChunk));
     }
 
     /**
@@ -345,7 +345,7 @@ contract ERC1155LazyPayableClaim is IERC165, IERC1155LazyPayableClaim, ICreatorE
         Claim memory claim = _claims[creatorContractAddress][instanceId];
 
         if (claim.storageProtocol == StorageProtocol.ADDRESS) {
-            return IERC1155LazyPayableClaimMetadata(_bytesToAddress(claim.location)).tokenURI(creatorContractAddress, tokenId, instanceId);
+            return IERC1155LazyPayableClaimMetadata(_bytesToAddress(bytes(claim.location))).tokenURI(creatorContractAddress, tokenId, instanceId);
         }
 
         string memory prefix = "";

--- a/packages/manifold/contracts/lazyclaim/ERC721LazyPayableClaim.sol
+++ b/packages/manifold/contracts/lazyclaim/ERC721LazyPayableClaim.sol
@@ -58,7 +58,7 @@ contract ERC721LazyPayableClaim is IERC165, IERC721LazyPayableClaim, ICreatorExt
 
         // Sanity checks
         if (claimParameters.storageProtocol == StorageProtocol.INVALID) revert ILazyPayableClaim.InvalidStorageProtocol();
-        if (claimParameters.storageProtocol == StorageProtocol.ADDRESS && claimParameters.location.length != 20) revert ILazyPayableClaim.InvalidStorageProtocol();
+        if (claimParameters.storageProtocol == StorageProtocol.ADDRESS && bytes(claimParameters.location).length != 20) revert ILazyPayableClaim.InvalidStorageProtocol();
         if (claimParameters.endDate != 0 && claimParameters.startDate >= claimParameters.endDate) revert ILazyPayableClaim.InvalidStartDate();
         require(claimParameters.merkleRoot == "" || claimParameters.walletMax == 0, "Cannot provide both walletMax and merkleRoot");
 
@@ -100,7 +100,7 @@ contract ERC721LazyPayableClaim is IERC165, IERC721LazyPayableClaim, ICreatorExt
         // Sanity checks
         Claim memory claim = _getClaim(creatorContractAddress, instanceId);
         if (claimParameters.storageProtocol == StorageProtocol.INVALID) revert ILazyPayableClaim.InvalidStorageProtocol();
-        if (claimParameters.storageProtocol == StorageProtocol.ADDRESS && claimParameters.location.length != 20) revert ILazyPayableClaim.InvalidStorageProtocol();
+        if (claimParameters.storageProtocol == StorageProtocol.ADDRESS && bytes(claimParameters.location).length != 20) revert ILazyPayableClaim.InvalidStorageProtocol();
         if (claimParameters.endDate != 0 && claimParameters.startDate >= claimParameters.endDate) revert ILazyPayableClaim.InvalidStartDate();
         if (claimParameters.erc20 != claim.erc20) revert ILazyPayableClaim.CannotChangePaymentToken();
         if (claimParameters.totalMax != 0 && claim.total > claimParameters.totalMax) {
@@ -134,11 +134,11 @@ contract ERC721LazyPayableClaim is IERC165, IERC721LazyPayableClaim, ICreatorExt
         address creatorContractAddress, uint256 instanceId,
         StorageProtocol storageProtocol,
         bool identical,
-        bytes calldata location
+        string calldata location
     ) external override creatorAdminRequired(creatorContractAddress) {
         Claim storage claim = _getClaim(creatorContractAddress, instanceId);
         if (storageProtocol == StorageProtocol.INVALID) revert ILazyPayableClaim.InvalidStorageProtocol();
-        if (storageProtocol == StorageProtocol.ADDRESS && location.length != 20) revert ILazyPayableClaim.InvalidStorageProtocol();
+        if (storageProtocol == StorageProtocol.ADDRESS && bytes(location).length != 20) revert ILazyPayableClaim.InvalidStorageProtocol();
 
         claim.storageProtocol = storageProtocol;
         claim.location = location;
@@ -151,11 +151,11 @@ contract ERC721LazyPayableClaim is IERC165, IERC721LazyPayableClaim, ICreatorExt
      */
     function extendTokenURI(
         address creatorContractAddress, uint256 instanceId,
-        bytes calldata locationChunk
+        string calldata locationChunk
     ) external override creatorAdminRequired(creatorContractAddress) {
         Claim storage claim = _getClaim(creatorContractAddress, instanceId);
         if (claim.storageProtocol != StorageProtocol.NONE || !claim.identical) revert ILazyPayableClaim.InvalidStorageProtocol();
-        claim.location = abi.encodePacked(claim.location, locationChunk);
+        claim.location = string(abi.encodePacked(claim.location, locationChunk));
         emit ClaimUpdated(creatorContractAddress, instanceId);
     }
 
@@ -403,7 +403,7 @@ contract ERC721LazyPayableClaim is IERC165, IERC721LazyPayableClaim, ICreatorExt
         }
 
         if (claim.storageProtocol == StorageProtocol.ADDRESS) {
-            return IERC721LazyPayableClaimMetadata(_bytesToAddress(claim.location)).tokenURI(creatorContractAddress, tokenId, instanceId, mintOrder);
+            return IERC721LazyPayableClaimMetadata(_bytesToAddress(bytes(claim.location))).tokenURI(creatorContractAddress, tokenId, instanceId, mintOrder);
         }
 
         string memory prefix = "";

--- a/packages/manifold/contracts/lazyclaim/IERC1155LazyPayableClaim.sol
+++ b/packages/manifold/contracts/lazyclaim/IERC1155LazyPayableClaim.sol
@@ -18,7 +18,7 @@ interface IERC1155LazyPayableClaim is ILazyPayableClaim {
         uint48 endDate;
         StorageProtocol storageProtocol;
         bytes32 merkleRoot;
-        bytes location;
+        string location;
         uint256 cost;
         address payable paymentReceiver;
         address erc20;
@@ -33,7 +33,7 @@ interface IERC1155LazyPayableClaim is ILazyPayableClaim {
         uint48 endDate;
         StorageProtocol storageProtocol;
         bytes32 merkleRoot;
-        bytes location;
+        string location;
         uint256 tokenId;
         uint256 cost;
         address payable paymentReceiver;
@@ -64,7 +64,7 @@ interface IERC1155LazyPayableClaim is ILazyPayableClaim {
      * @param storageProtocol           the new storage protocol
      * @param location                  the new location
      */
-    function updateTokenURIParams(address creatorContractAddress, uint256 instanceId, StorageProtocol storageProtocol, bytes calldata location) external;
+    function updateTokenURIParams(address creatorContractAddress, uint256 instanceId, StorageProtocol storageProtocol, string calldata location) external;
 
     /**
      * @notice extend tokenURI parameters for an existing claim at instanceId.  Must have NONE StorageProtocol
@@ -72,7 +72,7 @@ interface IERC1155LazyPayableClaim is ILazyPayableClaim {
      * @param instanceId                the claim instanceId for the creator contract
      * @param locationChunk             the additional location chunk
      */
-    function extendTokenURI(address creatorContractAddress, uint256 instanceId, bytes calldata locationChunk) external;
+    function extendTokenURI(address creatorContractAddress, uint256 instanceId, string calldata locationChunk) external;
 
     /**
      * @notice get a claim corresponding to a creator contract and instanceId

--- a/packages/manifold/contracts/lazyclaim/IERC721LazyPayableClaim.sol
+++ b/packages/manifold/contracts/lazyclaim/IERC721LazyPayableClaim.sol
@@ -18,7 +18,7 @@ interface IERC721LazyPayableClaim is ILazyPayableClaim {
         StorageProtocol storageProtocol;
         bool identical;
         bytes32 merkleRoot;
-        bytes location;
+        string location;
         uint256 cost;
         address payable paymentReceiver;
         address erc20;
@@ -35,7 +35,7 @@ interface IERC721LazyPayableClaim is ILazyPayableClaim {
         uint8 contractVersion;
         bool identical;
         bytes32 merkleRoot;
-        bytes location;
+        string location;
         uint256 cost;
         address payable paymentReceiver;
         address erc20;
@@ -66,7 +66,7 @@ interface IERC721LazyPayableClaim is ILazyPayableClaim {
      * @param identical                 the new value of identical
      * @param location                  the new location
      */
-    function updateTokenURIParams(address creatorContractAddress, uint256 instanceId, StorageProtocol storageProtocol, bool identical, bytes calldata location) external;
+    function updateTokenURIParams(address creatorContractAddress, uint256 instanceId, StorageProtocol storageProtocol, bool identical, string calldata location) external;
 
     /**
      * @notice extend tokenURI parameters for an existing claim at instanceId.  Must have NONE StorageProtocol
@@ -74,7 +74,7 @@ interface IERC721LazyPayableClaim is ILazyPayableClaim {
      * @param instanceId                the claim instanceId for the creator contract
      * @param locationChunk             the additional location chunk
      */
-    function extendTokenURI(address creatorContractAddress, uint256 instanceId, bytes calldata locationChunk) external;
+    function extendTokenURI(address creatorContractAddress, uint256 instanceId, string calldata locationChunk) external;
 
     /**
      * @notice get a claim corresponding to a creator contract and instanceId

--- a/packages/manifold/test/lazyclaim/ERC1155LazyPayableClaim.t.sol
+++ b/packages/manifold/test/lazyclaim/ERC1155LazyPayableClaim.t.sol
@@ -642,7 +642,7 @@ contract ERC1155LazyPayableClaimTest is Test {
 
     IERC1155LazyPayableClaim.ClaimParameters memory claimP = IERC1155LazyPayableClaim.ClaimParameters({
       merkleRoot: "",
-      location: abi.encodePacked(address(metadata)),
+      location: string(abi.encodePacked(address(metadata))),
       totalMax: 11,
       walletMax: 3,
       startDate: nowC,

--- a/packages/manifold/test/lazyclaim/ERC721LazyPayableClaim.t.sol
+++ b/packages/manifold/test/lazyclaim/ERC721LazyPayableClaim.t.sol
@@ -662,7 +662,7 @@ contract ERC721LazyPayableClaimTest is Test {
 
     IERC721LazyPayableClaim.ClaimParameters memory claimP = IERC721LazyPayableClaim.ClaimParameters({
       merkleRoot: "",
-      location: abi.encodePacked(address(metadata)),
+      location: string(abi.encodePacked(address(metadata))),
       totalMax: 11,
       walletMax: 3,
       startDate: nowC,


### PR DESCRIPTION
Use string locations even for ADDRESS location types in LazyClaim to avoid the need to convert strings to bytes in the common usage scenario.