### PR TITLE
generic manifold extension mint events

### DIFF
--- a/packages/manifold/contracts/libraries/IManifoldExtension.sol
+++ b/packages/manifold/contracts/libraries/IManifoldExtension.sol
@@ -9,6 +9,7 @@ interface IManifoldExtension {
     event InstanceMint(
         address creatorContractAddress,
         uint256 indexed instanceId,
+        address minter,
         address indexed tokenAddress,
         uint256 indexed tokenId,
         uint256 quantity
@@ -16,6 +17,7 @@ interface IManifoldExtension {
     event InstanceBatchMint(
         address creatorContractAddress,
         uint256 indexed instanceId,
+        address minter,
         address indexed tokenAddress,
         uint256[] indexed tokenIds,
         uint256[] quantity

--- a/packages/manifold/contracts/libraries/IManifoldExtension.sol
+++ b/packages/manifold/contracts/libraries/IManifoldExtension.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @title IManifoldExtension
+ * @notice Interface for Manifold extensions. It defines all the events that an extension will emit whenever a token is minted.
+ */
+interface IManifoldExtension {
+    event InstanceMint(
+        address creatorContractAddress,
+        uint256 indexed instanceId,
+        address indexed tokenAddress,
+        uint256 indexed tokenId,
+        uint256 quantity
+    );
+    event InstanceBatchMint(
+        address creatorContractAddress,
+        uint256 indexed instanceId,
+        address indexed tokenAddress,
+        uint256[] indexed tokenIds,
+        uint256[] quantity
+    );
+}


### PR DESCRIPTION
A generic manifold extension mint event.  This is intended to replace all extension specific mint events that are currently emitted.