### PR TITLE
updatable burn redeem contract

### DIFF
--- a/packages/manifold/contracts/burnredeemUpdatableFee/BurnRedeemCoreV2.sol
+++ b/packages/manifold/contracts/burnredeemUpdatableFee/BurnRedeemCoreV2.sol
@@ -1,0 +1,610 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/////////////////////////////////////////////////////////////////////////////////////
+//                                                                                 //
+//                                                                                 //
+//                                     .%(#.                                       //
+//                                      #(((#%,                                    //
+//                                      (#(((((#%*                                 //
+//                                      /#((((((((##*                              //
+//                                      (#((((((((((##%.                           //
+//                                     ,##(/*/(////((((#%*                         //
+//                                   .###(//****/////(((##%,                       //
+//                  (,          ,%#((((((///******/////((##%(                      //
+//                *((,         ,##(///////*********////((###%*                     //
+//              /((((         ,##(//////************/(((((###%                     //
+//             /((((         ,##((////***************/((((###%                     //
+//             (((          .###((///*****************((((####                     //
+//             .            (##((//*******************((((##%*                     //
+//               (#.       .###((/********************((((##%.      %.             //
+//             ,%(#.       .###(/********,,,,,,,*****/(((###%#     ((%,            //
+//            /%#/(/       /###(//****,,,,,,,,,,,****/((((((##%%%%#((#%.           //
+//           /##(//(#.    ,###((/****,,,,,,,,,,,,,***/((/(((((((((#####%           //
+//          *%##(/////((###((((/***,,,,,,,,,,,,,,,***//((((((((((####%%%/          //
+//          ####(((//////(//////**,,,,,,.....,,,,,,****/(((((//((####%%%%          //
+//         .####(((/((((((/////**,,,,,.......,,,,,,,,*****/////(#####%%%%          //
+//         .#%###((////(((//***,,,,,,..........,,,,,,,,*****//((#####%%%%          //
+//          /%%%###/////*****,,,,,,,..............,,,,,,,****/(((####%%%%          //
+//           /%%###(////****,,,,,,.....        ......,,,,,,**(((####%%%%           //
+//            ,#%###(///****,,,,,....            .....,,,,,***/(/(##%%(            //
+//              (####(//****,,....                 ....,,,,,***/(####              //
+//                (###(/***,,,...                    ...,,,,***(##/                //
+//             #.   (#((/**,,,,..                    ...,,,,*((#,                  //
+//               ,#(##(((//,,,,..                   ...,,,*/(((#((/                //
+//                  *#(((///*,,....                ....,*//((((                    //
+//                      *(///***,....            ...,***//,                        //
+//                           ,//***,...       ..,,*,                               //
+//                                                                                 //
+//                                                                                 //
+/////////////////////////////////////////////////////////////////////////////////////
+
+import "@manifoldxyz/creator-core-solidity/contracts/extensions/ICreatorExtensionTokenURI.sol";
+import "@manifoldxyz/libraries-solidity/contracts/access/AdminControl.sol";
+import "@manifoldxyz/libraries-solidity/contracts/access/IAdminControl.sol";
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
+import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+
+import ".././libraries/manifold-membership/IManifoldMembership.sol";
+import "./BurnRedeemLibV2.sol";
+import "./IBurnRedeemCoreV2.sol";
+import "./Interfaces.sol";
+
+/**
+ * @title Burn Redeem Core V2
+ * @author manifold.xyz
+ * @notice Core logic for Burn Redeem shared extensions.
+ */
+abstract contract BurnRedeemCoreV2 is ERC165, AdminControl, ReentrancyGuard, IBurnRedeemCoreV2, ICreatorExtensionTokenURI {
+    using Strings for uint256;
+
+    uint256 public BURN_FEE;
+    uint256 public MULTI_BURN_FEE;
+
+    string internal constant ARWEAVE_PREFIX = "https://arweave.net/";
+    string internal constant IPFS_PREFIX = "ipfs://";
+
+    uint256 internal constant MAX_UINT_16 = 0xffff;
+    uint256 internal constant MAX_UINT_24 = 0xffffff;
+    uint256 internal constant MAX_UINT_32 = 0xffffffff;
+    uint256 internal constant MAX_UINT_56 = 0xffffffffffffff;
+    uint256 internal constant MAX_UINT_256 = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+
+    // { creatorContractAddress => { instanceId => BurnRedeem } }
+    mapping(address => mapping(uint256 => BurnRedeem)) internal _burnRedeems;
+
+    bool public active = true;
+    address public manifoldMembershipContract;
+
+    constructor(address initialOwner) {
+        _transferOwnership(initialOwner);
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view virtual override(IERC165, ERC165, AdminControl) returns (bool) {
+        return interfaceId == type(IBurnRedeemCoreV2).interfaceId ||
+            interfaceId == type(IERC721Receiver).interfaceId ||
+            interfaceId == type(IERC1155Receiver).interfaceId ||
+            interfaceId == type(ICreatorExtensionTokenURI).interfaceId ||
+            super.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @notice This extension is shared, not single-creator. So we must ensure
+     * that a burn redeems's initializer is an admin on the creator contract
+     * @param creatorContractAddress    the address of the creator contract to check the admin against
+     */
+    function _validateAdmin(address creatorContractAddress) internal view {
+        if (!IAdminControl(creatorContractAddress).isAdmin(msg.sender)) {
+            revert NotAdmin(creatorContractAddress);
+        }
+    }
+
+    /**
+     * Initialiazes a burn redeem with base parameters
+     */
+    function _initialize(
+        address creatorContractAddress,
+        uint8 creatorContractVersion,
+        uint256 instanceId,
+        BurnRedeemParameters calldata burnRedeemParameters
+    ) internal {
+         if (!active) revert Inactive();
+        BurnRedeemLibV2.initialize(creatorContractAddress, creatorContractVersion, instanceId, _burnRedeems[creatorContractAddress][instanceId], burnRedeemParameters);
+    }
+
+    /**
+     * Updates a burn redeem with base parameters
+     */
+    function _update(
+        address creatorContractAddress,
+        uint256 instanceId,
+        BurnRedeemParameters calldata burnRedeemParameters
+    ) internal {
+        BurnRedeemLibV2.update(creatorContractAddress, instanceId, _getBurnRedeem(creatorContractAddress, instanceId), burnRedeemParameters);
+    }
+
+    /**
+     * See {IBurnRedeemCoreV2-getBurnRedeem}.
+     */
+    function getBurnRedeem(address creatorContractAddress, uint256 instanceId) external override view returns(BurnRedeem memory) {
+        return _getBurnRedeem(creatorContractAddress, instanceId);
+    }
+
+    /**
+     * Helper to get burn redeem instance
+     */
+    function _getBurnRedeem(address creatorContractAddress, uint256 instanceId) internal view returns(BurnRedeem storage burnRedeemInstance) {
+        burnRedeemInstance = _burnRedeems[creatorContractAddress][instanceId];
+        if (burnRedeemInstance.storageProtocol == StorageProtocol.INVALID) {
+            revert BurnRedeemDoesNotExist(instanceId);
+        }
+    }
+
+    /**
+     * Helper to get active burn redeem instance
+     */
+    function _getActiveBurnRedeem(address creatorContractAddress, uint256 instanceId) private view returns(BurnRedeem storage burnRedeemInstance) {
+        burnRedeemInstance = _getBurnRedeem(creatorContractAddress, instanceId);
+        if (burnRedeemInstance.startDate > block.timestamp || (block.timestamp >= burnRedeemInstance.endDate && burnRedeemInstance.endDate != 0)) {
+            revert BurnRedeemInactive(instanceId);
+        }
+    }
+
+    /**
+     * See {IBurnRedeemCoreV2-burnRedeem}.
+     */
+    function burnRedeem(address creatorContractAddress, uint256 instanceId, uint32 burnRedeemCount, BurnToken[] calldata burnTokens) external payable override nonReentrant {
+        uint256 payableCost = _burnRedeem(msg.value, creatorContractAddress, instanceId, burnRedeemCount, burnTokens, _isActiveMember(msg.sender), true, "");
+        if (msg.value > payableCost) {
+            _forwardValue(payable(msg.sender), msg.value - payableCost);
+        }
+    }
+
+    /**
+     * (Batch overload) see {IBurnRedeemCoreV2-burnRedeem}.
+     */
+    function burnRedeem(address[] calldata creatorContractAddresses, uint256[] calldata instanceIds, uint32[] calldata burnRedeemCounts, BurnToken[][] calldata burnTokens) external payable override nonReentrant {
+        if (creatorContractAddresses.length != instanceIds.length ||
+            creatorContractAddresses.length != burnRedeemCounts.length ||
+            creatorContractAddresses.length != burnTokens.length) {
+            revert InvalidInput();
+        }
+
+        bool isActiveMember = _isActiveMember(msg.sender);
+        uint256 msgValueRemaining = msg.value;
+        for (uint256 i; i < creatorContractAddresses.length;) {
+            msgValueRemaining -= _burnRedeem(msgValueRemaining, creatorContractAddresses[i], instanceIds[i], burnRedeemCounts[i], burnTokens[i], isActiveMember, false, "");
+            unchecked { ++i; }
+        }
+
+        if (msgValueRemaining != 0) {
+            _forwardValue(payable(msg.sender), msgValueRemaining);
+        }
+    }
+
+    /**
+     * See {IBurnRedeemCoreV2-burnRedeemWithData}.
+     */
+    function burnRedeemWithData(address creatorContractAddress, uint256 instanceId, uint32 burnRedeemCount, BurnToken[] calldata burnTokens, bytes calldata data) external payable override nonReentrant {
+        uint256 payableCost = _burnRedeem(msg.value, creatorContractAddress, instanceId, burnRedeemCount, burnTokens, _isActiveMember(msg.sender), true, data);
+        if (msg.value > payableCost) {
+            _forwardValue(payable(msg.sender), msg.value - payableCost);
+        }
+    }
+
+    /**
+     * See {IBurnRedeemCoreV2-airdrop}.
+     */
+    function airdrop(address creatorContractAddress, uint256 instanceId, address[] calldata recipients, uint32[] calldata amounts) external override {
+        _validateAdmin(creatorContractAddress);
+        if (recipients.length != amounts.length) {
+            revert InvalidInput();
+        }
+        BurnRedeem storage burnRedeemInstance = _getBurnRedeem(creatorContractAddress, instanceId);
+
+        uint256 totalAmount;
+        for (uint256 i; i < amounts.length;) {
+            totalAmount += amounts[i] * burnRedeemInstance.redeemAmount;
+            unchecked{ ++i; }
+        }
+        if (totalAmount + burnRedeemInstance.redeemedCount > MAX_UINT_32) {
+            revert InvalidRedeemAmount();
+        }
+
+        // Airdrop the tokens
+        for (uint256 i; i < recipients.length;) {
+            _redeem(creatorContractAddress, instanceId, burnRedeemInstance, recipients[i], amounts[i], "");
+            unchecked{ ++i; }
+        }
+
+        BurnRedeemLibV2.syncTotalSupply(burnRedeemInstance);
+    }
+
+    function _burnRedeem(uint256 msgValue, address creatorContractAddress, uint256 instanceId, uint32 burnRedeemCount, BurnToken[] calldata burnTokens, bool isActiveMember, bool revertNoneRemaining, bytes memory data) private returns (uint256) {
+        BurnRedeem storage burnRedeemInstance = _getActiveBurnRedeem(creatorContractAddress, instanceId);
+
+        // Get the amount that can be burned
+        burnRedeemCount = _getAvailableBurnRedeemCount(burnRedeemInstance.totalSupply, burnRedeemInstance.redeemedCount, burnRedeemInstance.redeemAmount, burnRedeemCount, revertNoneRemaining);
+        if (burnRedeemCount == 0) {
+            return 0;
+        }
+
+        uint256 payableCost = burnRedeemInstance.cost;
+        uint256 cost = burnRedeemInstance.cost;
+        if (!isActiveMember) {
+            payableCost += burnTokens.length <= 1 ? BURN_FEE : MULTI_BURN_FEE;
+        }
+        if (burnRedeemCount > 1) {
+            payableCost *= burnRedeemCount;
+            cost *= burnRedeemCount;
+        }
+        if (payableCost > msgValue) {
+            revert InvalidPaymentAmount();
+        }
+        if (cost > 0) {
+            _forwardValue(burnRedeemInstance.paymentReceiver, cost);
+        }
+
+        // Do burn redeem
+        _burnTokens(burnRedeemInstance, burnTokens, burnRedeemCount, msg.sender, data);
+        _redeem(creatorContractAddress, instanceId, burnRedeemInstance, msg.sender, burnRedeemCount, data);
+
+        return payableCost;
+    }
+
+    /**
+     * @dev See {IBurnRedeemCoreV2-recoverERC721}.
+     */
+    function recoverERC721(address tokenAddress, uint256 tokenId, address destination) external override adminRequired {
+        IERC721(tokenAddress).transferFrom(address(this), destination, tokenId);
+    }
+
+    /**
+     * @dev See {IBurnRedeemCoreV2-withdraw}.
+     */
+    function withdraw(address payable recipient, uint256 amount) external override adminRequired {
+        _forwardValue(recipient, amount);
+    }
+
+    /**
+     * @dev See {IBurnRedeemCoreV2-setManifoldMembership}.
+     */
+    function setMembershipAddress(address addr) external override adminRequired {
+        manifoldMembershipContract = addr;
+    }
+
+    /**
+     * See {IBurnRedeemCoreV2-setBurnFees}.
+     */
+    function setBurnFees(uint256 burnFee, uint256 multiBurnFee) external override adminRequired {
+        BURN_FEE = burnFee;
+        MULTI_BURN_FEE = multiBurnFee;
+    }
+
+    /**
+     * See {IBurnRedeemCoreV2-setActive}.
+     */
+    function setActive(bool _active) external override adminRequired {
+        active = _active;
+    }
+
+    /**
+     * @dev See {IERC721Receiver-onERC721Received}.
+     */
+    function onERC721Received(
+        address,
+        address from,
+        uint256 id,
+        bytes calldata data
+    ) external override nonReentrant returns(bytes4) {
+        _onERC721Received(from, id, data);
+        return this.onERC721Received.selector;
+    }
+
+    /**
+     * @dev See {IERC1155Receiver-onERC1155Received}.
+     */
+    function onERC1155Received(
+        address,
+        address from,
+        uint256 id,
+        uint256 value,
+        bytes calldata data
+    ) external override nonReentrant returns(bytes4) {
+        // Check calldata is valid
+        if (data.length % 32 != 0) {
+            revert InvalidData();
+        }
+
+        address creatorContractAddress;
+        uint256 instanceId;
+        uint32 burnRedeemCount;
+        uint256 burnItemIndex;
+        bytes32[] memory merkleProof;
+        (creatorContractAddress, instanceId, burnRedeemCount, burnItemIndex, merkleProof) = abi.decode(data, (address, uint256, uint32, uint256, bytes32[]));
+
+        // Do burn redeem
+        _onERC1155Received(from, id, value, creatorContractAddress, instanceId, burnRedeemCount, burnItemIndex, merkleProof);
+
+        return this.onERC1155Received.selector;
+    }
+
+    /**
+     * @dev See {IERC1155Receiver-onERC1155BatchReceived}.
+     */
+    function onERC1155BatchReceived(
+        address,
+        address from,
+        uint256[] calldata ids,
+        uint256[] calldata values,
+        bytes calldata data
+    ) external override nonReentrant returns(bytes4) {
+        // Check calldata is valid
+        if (data.length % 32 != 0) {
+            revert InvalidData();
+        }
+
+        address creatorContractAddress;
+        uint256 instanceId;
+        uint32 burnRedeemCount;
+        BurnToken[] memory burnTokens;
+        (creatorContractAddress, instanceId, burnRedeemCount, burnTokens) = abi.decode(data, (address, uint256, uint32, BurnToken[]));
+
+        // Do burn redeem
+        _onERC1155BatchReceived(from, ids, values, creatorContractAddress, instanceId, burnRedeemCount, burnTokens);
+
+        return this.onERC1155BatchReceived.selector;
+    }
+
+    /**
+     * @notice ERC721 token transfer callback
+     * @param from      the person sending the tokens
+     * @param id        the token id of the burn token
+     * @param data      bytes indicating the target burnRedeem and, optionally, a merkle proof that the token is valid
+     */
+    function _onERC721Received(
+        address from,
+        uint256 id,
+        bytes calldata data
+    ) private {
+        // Check calldata is valid
+        if (data.length % 32 != 0) {
+            revert InvalidData();
+        }
+
+        address creatorContractAddress;
+        uint256 instanceId;
+        uint256 burnItemIndex;
+        bytes32[] memory merkleProof;
+        (creatorContractAddress, instanceId, burnItemIndex, merkleProof) = abi.decode(data, (address, uint256, uint256, bytes32[]));
+
+        BurnRedeem storage burnRedeemInstance = _getActiveBurnRedeem(creatorContractAddress, instanceId);
+
+        // A single ERC721 can only be sent in directly for a burn if:
+        // 1. There is no cost to the burn (because no payment can be sent with a transfer)
+        // 2. The burn only requires one NFT (one burnSet element and one count)
+        // 3. They are an active member (because no fee payment can be sent with a transfer)
+        _validateReceivedInput(burnRedeemInstance.cost, burnRedeemInstance.burnSet.length, burnRedeemInstance.burnSet[0].requiredCount, from);
+
+        _getAvailableBurnRedeemCount(burnRedeemInstance.totalSupply, burnRedeemInstance.redeemedCount, burnRedeemInstance.redeemAmount, 1, true);
+
+        // Check that the burn token is valid
+        BurnItem memory burnItem = burnRedeemInstance.burnSet[0].items[burnItemIndex];
+
+        // Can only take in one burn item
+        if (burnItem.tokenSpec != TokenSpec.ERC721) {
+            revert InvalidInput();
+        }
+        BurnRedeemLibV2.validateBurnItem(burnItem, msg.sender, id, merkleProof);
+
+        // Do burn and redeem
+        _burn(burnItem, address(this), msg.sender, id, 1, "");
+        _redeem(creatorContractAddress, instanceId, burnRedeemInstance, from, 1, "");
+    }
+
+    /**
+     * Execute onERC1155Received burn/redeem
+     */
+    function _onERC1155Received(address from, uint256 tokenId, uint256 value, address creatorContractAddress, uint256 instanceId, uint32 burnRedeemCount, uint256 burnItemIndex, bytes32[] memory merkleProof) private {
+        BurnRedeem storage burnRedeemInstance = _getActiveBurnRedeem(creatorContractAddress, instanceId);
+
+        // A single 1155 can only be sent in directly for a burn if:
+        // 1. There is no cost to the burn (because no payment can be sent with a transfer)
+        // 2. The burn only requires one NFT (one burn set element and one required count in the set)
+        // 3. They are an active member (because no fee payment can be sent with a transfer)
+        _validateReceivedInput(burnRedeemInstance.cost, burnRedeemInstance.burnSet.length, burnRedeemInstance.burnSet[0].requiredCount, from);
+
+        uint32 availableBurnRedeemCount = _getAvailableBurnRedeemCount(burnRedeemInstance.totalSupply, burnRedeemInstance.redeemedCount, burnRedeemInstance.redeemAmount, burnRedeemCount, true);
+
+        // Check that the burn token is valid
+        BurnItem memory burnItem = burnRedeemInstance.burnSet[0].items[burnItemIndex];
+        if (value != burnItem.amount * burnRedeemCount) {
+            revert InvalidBurnAmount();
+        }
+        BurnRedeemLibV2.validateBurnItem(burnItem, msg.sender, tokenId, merkleProof);
+
+        _burn(burnItem, address(this), msg.sender, tokenId, availableBurnRedeemCount, "");
+        _redeem(creatorContractAddress, instanceId, burnRedeemInstance, from, availableBurnRedeemCount, "");
+
+        // Return excess amount
+        if (availableBurnRedeemCount != burnRedeemCount) {
+            IERC1155(msg.sender).safeTransferFrom(address(this), from, tokenId, (burnRedeemCount - availableBurnRedeemCount) * burnItem.amount, "");
+        }
+    }
+
+    /**
+     * Execute onERC1155BatchReceived burn/redeem
+     */
+    function _onERC1155BatchReceived(address from, uint256[] calldata tokenIds, uint256[] calldata values, address creatorContractAddress, uint256 instanceId, uint32 burnRedeemCount, BurnToken[] memory burnTokens) private {
+        BurnRedeem storage burnRedeemInstance = _getActiveBurnRedeem(creatorContractAddress, instanceId);
+
+        // A single 1155 can only be sent in directly for a burn if:
+        // 1. There is no cost to the burn (because no payment can be sent with a transfer)
+        // 2. We have the right data length
+        // 3. They are an active member (because no fee payment can be sent with a transfer)
+        if (burnRedeemInstance.cost != 0 || burnTokens.length != tokenIds.length || !_isActiveMember(from)) {
+            revert InvalidInput();
+        }
+        uint32 availableBurnRedeemCount = _getAvailableBurnRedeemCount(burnRedeemInstance.totalSupply, burnRedeemInstance.redeemedCount, burnRedeemInstance.redeemAmount, burnRedeemCount, true);
+
+        // Verify the values match what is needed
+        uint256[] memory returnValues = new uint256[](tokenIds.length);
+        for (uint256 i; i < burnTokens.length;) {
+            BurnToken memory burnToken = burnTokens[i];
+            BurnItem memory burnItem = burnRedeemInstance.burnSet[burnToken.groupIndex].items[burnToken.itemIndex];
+            if (burnToken.contractAddress != msg.sender || burnToken.id != tokenIds[i]) {
+                revert InvalidToken(tokenIds[i]);
+            }
+            if (burnItem.amount * burnRedeemCount != values[i]) {
+                revert InvalidRedeemAmount();
+            }
+            if (availableBurnRedeemCount != burnRedeemCount) {
+                returnValues[i] = values[i] - burnItem.amount * availableBurnRedeemCount;
+            }
+            unchecked { ++i; }
+        }
+
+        // Do burn redeem
+        _burnTokens(burnRedeemInstance, burnTokens, availableBurnRedeemCount, address(this), "");
+        _redeem(creatorContractAddress, instanceId, burnRedeemInstance, from, availableBurnRedeemCount, "");
+
+        // Return excess amount
+        if (availableBurnRedeemCount != burnRedeemCount) {
+            IERC1155(msg.sender).safeBatchTransferFrom(address(this), from, tokenIds, returnValues, "");
+        }
+    }
+
+    function _validateReceivedInput(uint256 cost, uint256 length, uint256 requiredCount, address from) private view {
+        if (cost != 0 || length != 1 || requiredCount != 1 || !_isActiveMember(from)) {
+            revert InvalidInput();
+        }
+    }
+
+    /**
+     * Send funds to receiver
+     */
+    function _forwardValue(address payable receiver, uint256 amount) private {
+        (bool sent, ) = receiver.call{value: amount}("");
+        if (!sent) {
+            revert TransferFailure();
+        }
+    }
+
+    /**
+     * Burn all listed tokens and check that the burn set is satisfied
+     */
+    function _burnTokens(BurnRedeem storage burnRedeemInstance, BurnToken[] memory burnTokens, uint256 burnRedeemCount, address owner, bytes memory data) private {
+        // Check that each group in the burn set is satisfied
+        uint256[] memory groupCounts = new uint256[](burnRedeemInstance.burnSet.length);
+
+        for (uint256 i; i < burnTokens.length;) {
+            BurnToken memory burnToken = burnTokens[i];
+            BurnItem memory burnItem = burnRedeemInstance.burnSet[burnToken.groupIndex].items[burnToken.itemIndex];
+
+            BurnRedeemLibV2.validateBurnItem(burnItem, burnToken.contractAddress, burnToken.id, burnToken.merkleProof);
+
+            _burn(burnItem, owner, burnToken.contractAddress, burnToken.id, burnRedeemCount, data);
+            groupCounts[burnToken.groupIndex] += burnRedeemCount;
+
+            unchecked { ++i; }
+        }
+
+        for (uint256 i; i < groupCounts.length;) {
+            if (groupCounts[i] != burnRedeemInstance.burnSet[i].requiredCount * burnRedeemCount) {
+                revert InvalidBurnAmount();
+            }
+            unchecked { ++i; }
+        }
+    }
+
+    /**
+     * Helper to check if the sender holds an active Manifold membership
+     */
+    function _isActiveMember(address sender) private view returns(bool) {
+        return manifoldMembershipContract != address(0) &&
+            IManifoldMembership(manifoldMembershipContract).isActiveMember(sender);
+    }
+
+    /**
+     * Helper to get the number of burn redeems the person can accomplish
+     */
+    function _getAvailableBurnRedeemCount(uint32 totalSupply, uint32 redeemedCount, uint32 redeemAmount, uint32 desiredCount, bool revertNoneRemaining) internal pure returns(uint32 burnRedeemCount) {
+        if (totalSupply == 0) {
+            burnRedeemCount = desiredCount;
+        } else {
+            uint32 remainingCount = (totalSupply - redeemedCount) / redeemAmount;
+            if (remainingCount > desiredCount) {
+                burnRedeemCount = desiredCount;
+            } else {
+                burnRedeemCount = remainingCount;
+            }
+        }
+
+        if (revertNoneRemaining && burnRedeemCount == 0) {
+            revert InvalidRedeemAmount();
+        }
+    }
+
+    /** 
+     * Abstract helper to mint multiple redeem tokens. To be implemented by inheriting contracts.
+     */
+    function _redeem(address creatorContractAddress, uint256 instanceId, BurnRedeem storage burnRedeemInstance, address to, uint32 count, bytes memory data) internal virtual;
+
+    /**
+     * Helper to burn token
+     */
+    function _burn(BurnItem memory burnItem, address from, address contractAddress, uint256 tokenId, uint256 burnRedeemCount, bytes memory data) private {
+        if (burnItem.tokenSpec == TokenSpec.ERC1155) {
+            uint256 amount = burnItem.amount * burnRedeemCount;
+
+            if (burnItem.burnSpec == BurnSpec.NONE) {
+                // Send to 0xdEaD to burn if contract doesn't have burn function
+                IERC1155(contractAddress).safeTransferFrom(from, address(0xdEaD), tokenId, amount, data);
+
+            } else if (burnItem.burnSpec == BurnSpec.MANIFOLD) {
+                // Burn using the creator core's burn function
+                uint256[] memory tokenIds = new uint256[](1);
+                tokenIds[0] = tokenId;
+                uint256[] memory amounts = new uint256[](1);
+                amounts[0] = amount;
+                Manifold1155(contractAddress).burn(from, tokenIds, amounts);
+
+            } else if (burnItem.burnSpec == BurnSpec.OPENZEPPELIN) {
+                // Burn using OpenZeppelin's burn function
+                OZBurnable1155(contractAddress).burn(from, tokenId, amount);
+
+            } else {
+                revert InvalidBurnSpec();
+            }
+        } else if (burnItem.tokenSpec == TokenSpec.ERC721) {
+            if (burnRedeemCount != 1) {
+                revert InvalidBurnAmount();
+            } 
+            if (burnItem.burnSpec == BurnSpec.NONE) {
+                // Send to 0xdEaD to burn if contract doesn't have burn function
+                IERC721(contractAddress).safeTransferFrom(from, address(0xdEaD), tokenId, data);
+
+            } else if (burnItem.burnSpec == BurnSpec.MANIFOLD || burnItem.burnSpec == BurnSpec.OPENZEPPELIN) {
+                if (from != address(this)) {
+                    // 721 `burn` functions do not have a `from` parameter, so we must verify the owner
+                    if (IERC721(contractAddress).ownerOf(tokenId) != from) {
+                        revert TransferFailure();
+                    }
+                }
+                // Burn using the contract's burn function
+                Burnable721(contractAddress).burn(tokenId);
+
+            } else {
+                revert InvalidBurnSpec();
+            }
+        } else {
+            revert InvalidTokenSpec();
+        }
+    }
+}

--- a/packages/manifold/contracts/burnredeemUpdatableFee/BurnRedeemCoreV2.sol
+++ b/packages/manifold/contracts/burnredeemUpdatableFee/BurnRedeemCoreV2.sol
@@ -114,7 +114,7 @@ abstract contract BurnRedeemCoreV2 is ERC165, AdminControl, ReentrancyGuard, IBu
         uint256 instanceId,
         BurnRedeemParameters calldata burnRedeemParameters
     ) internal {
-         if (!active) revert Inactive();
+        if (!active) revert Inactive();
         BurnRedeemLibV2.initialize(creatorContractAddress, creatorContractVersion, instanceId, _burnRedeems[creatorContractAddress][instanceId], burnRedeemParameters);
     }
 

--- a/packages/manifold/contracts/burnredeemUpdatableFee/BurnRedeemLibV2.sol
+++ b/packages/manifold/contracts/burnredeemUpdatableFee/BurnRedeemLibV2.sol
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/////////////////////////////////////////////////////////////////////////////////////
+//                                                                                 //
+//                                                                                 //
+//                                     .%(#.                                       //
+//                                      #(((#%,                                    //
+//                                      (#(((((#%*                                 //
+//                                      /#((((((((##*                              //
+//                                      (#((((((((((##%.                           //
+//                                     ,##(/*/(////((((#%*                         //
+//                                   .###(//****/////(((##%,                       //
+//                  (,          ,%#((((((///******/////((##%(                      //
+//                *((,         ,##(///////*********////((###%*                     //
+//              /((((         ,##(//////************/(((((###%                     //
+//             /((((         ,##((////***************/((((###%                     //
+//             (((          .###((///*****************((((####                     //
+//             .            (##((//*******************((((##%*                     //
+//               (#.       .###((/********************((((##%.      %.             //
+//             ,%(#.       .###(/********,,,,,,,*****/(((###%#     ((%,            //
+//            /%#/(/       /###(//****,,,,,,,,,,,****/((((((##%%%%#((#%.           //
+//           /##(//(#.    ,###((/****,,,,,,,,,,,,,***/((/(((((((((#####%           //
+//          *%##(/////((###((((/***,,,,,,,,,,,,,,,***//((((((((((####%%%/          //
+//          ####(((//////(//////**,,,,,,.....,,,,,,****/(((((//((####%%%%          //
+//         .####(((/((((((/////**,,,,,.......,,,,,,,,*****/////(#####%%%%          //
+//         .#%###((////(((//***,,,,,,..........,,,,,,,,*****//((#####%%%%          //
+//          /%%%###/////*****,,,,,,,..............,,,,,,,****/(((####%%%%          //
+//           /%%###(////****,,,,,,.....        ......,,,,,,**(((####%%%%           //
+//            ,#%###(///****,,,,,....            .....,,,,,***/(/(##%%(            //
+//              (####(//****,,....                 ....,,,,,***/(####              //
+//                (###(/***,,,...                    ...,,,,***(##/                //
+//             #.   (#((/**,,,,..                    ...,,,,*((#,                  //
+//               ,#(##(((//,,,,..                   ...,,,*/(((#((/                //
+//                  *#(((///*,,....                ....,*//((((                    //
+//                      *(///***,....            ...,***//,                        //
+//                           ,//***,...       ..,,*,                               //
+//                                                                                 //
+//                                                                                 //
+/////////////////////////////////////////////////////////////////////////////////////
+
+import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+import "./IBurnRedeemCoreV2.sol";
+
+/**
+ * @title Burn Redeem Lib V2
+ * @author manifold.xyz
+ * @notice Library for Burn Redeem shared extensions.
+ */
+library BurnRedeemLibV2 {
+
+    event BurnRedeemInitialized(address indexed creatorContract, uint256 indexed instanceId, address initializer);
+    event BurnRedeemUpdated(address indexed creatorContract, uint256 indexed instanceId);
+    event BurnRedeemMint(address indexed creatorContract, uint256 indexed instanceId, uint256 indexed tokenId, uint32 redeemedCount, bytes data);
+
+    error BurnRedeemAlreadyInitialized();
+    error InvalidBurnItem();
+    error InvalidBurnToken();
+    error InvalidMerkleProof();
+    error InvalidStorageProtocol();
+    error InvalidPaymentReceiver();
+    error InvalidDates();
+    error InvalidInput();
+
+    /**
+     * Initialiazes a burn redeem with base parameters
+     */
+    function initialize(
+        address creatorContractAddress,
+        uint8 creatorContractVersion,
+        uint256 instanceId,
+        IBurnRedeemCoreV2.BurnRedeem storage burnRedeemInstance,
+        IBurnRedeemCoreV2.BurnRedeemParameters calldata burnRedeemParameters
+    ) public {
+        // Sanity checks
+        if (burnRedeemInstance.storageProtocol != IBurnRedeemCoreV2.StorageProtocol.INVALID) {
+            revert BurnRedeemAlreadyInitialized();
+        }
+        _validateParameters(burnRedeemParameters);
+
+        // Create the burn redeem
+        burnRedeemInstance.contractVersion = creatorContractVersion;
+        _setParameters(burnRedeemInstance, burnRedeemParameters);
+        _setBurnGroups(burnRedeemInstance, burnRedeemParameters.burnSet);
+
+        emit BurnRedeemInitialized(creatorContractAddress, instanceId, msg.sender);
+    }
+
+    /**
+     * Updates a burn redeem with base parameters
+     */
+    function update(
+        address creatorContractAddress,
+        uint256 instanceId,
+        IBurnRedeemCoreV2.BurnRedeem storage burnRedeemInstance,
+        IBurnRedeemCoreV2.BurnRedeemParameters calldata burnRedeemParameters
+    ) public {
+        // Sanity checks
+        if (burnRedeemInstance.storageProtocol == IBurnRedeemCoreV2.StorageProtocol.INVALID) {
+            revert IBurnRedeemCoreV2.BurnRedeemDoesNotExist(instanceId);
+        }
+        _validateParameters(burnRedeemParameters);
+        // The current redeemedCount must be divisible by redeemAmount
+        if (burnRedeemInstance.redeemedCount % burnRedeemParameters.redeemAmount != 0) {
+            revert IBurnRedeemCoreV2.InvalidRedeemAmount();
+        }
+
+        // Overwrite the existing burnRedeem
+        _setParameters(burnRedeemInstance, burnRedeemParameters);
+        _setBurnGroups(burnRedeemInstance, burnRedeemParameters.burnSet);
+        syncTotalSupply(burnRedeemInstance);
+        emit BurnRedeemUpdated(creatorContractAddress, instanceId);
+    }
+
+    /**
+     * Helper to update total supply if redeemedCount exceeds totalSupply after airdrop or instance update.
+     */
+    function syncTotalSupply(IBurnRedeemCoreV2.BurnRedeem storage burnRedeemInstance) public {
+        if (
+            burnRedeemInstance.totalSupply != 0 &&
+            burnRedeemInstance.redeemedCount > burnRedeemInstance.totalSupply
+        ) {
+            burnRedeemInstance.totalSupply = burnRedeemInstance.redeemedCount;
+        }
+    }
+
+    /*
+     * Helper to validate burn item
+     */
+    function validateBurnItem(IBurnRedeemCoreV2.BurnItem memory burnItem, address contractAddress, uint256 tokenId, bytes32[] memory merkleProof) public pure {
+        if (burnItem.validationType == IBurnRedeemCoreV2.ValidationType.ANY) {
+            return;
+        }
+        if (contractAddress != burnItem.contractAddress) {
+            revert InvalidBurnToken();
+        }
+        if (burnItem.validationType == IBurnRedeemCoreV2.ValidationType.CONTRACT) {
+            return;
+        } else if (burnItem.validationType == IBurnRedeemCoreV2.ValidationType.RANGE) {
+            if (tokenId < burnItem.minTokenId || tokenId > burnItem.maxTokenId) {
+                revert IBurnRedeemCoreV2.InvalidToken(tokenId);
+            }
+            return;
+        } else if (burnItem.validationType == IBurnRedeemCoreV2.ValidationType.MERKLE_TREE) {
+            bytes32 leaf = keccak256(abi.encodePacked(tokenId));
+            if (!MerkleProof.verify(merkleProof, burnItem.merkleRoot, leaf)) {
+                revert InvalidMerkleProof();
+            }
+            return;
+        }
+        revert InvalidBurnItem();
+    }
+
+    /**
+     * Helper to validate the parameters for a burn redeem
+     */
+    function _validateParameters(IBurnRedeemCoreV2.BurnRedeemParameters calldata burnRedeemParameters) internal pure {
+        if (burnRedeemParameters.storageProtocol == IBurnRedeemCoreV2.StorageProtocol.INVALID) {
+            revert InvalidStorageProtocol();
+        }
+        if (burnRedeemParameters.paymentReceiver == address(0)) {
+            revert InvalidPaymentReceiver();
+        }
+        if (burnRedeemParameters.endDate != 0 && burnRedeemParameters.startDate >= burnRedeemParameters.endDate) {
+            revert InvalidDates();
+        }
+        if (burnRedeemParameters.totalSupply % burnRedeemParameters.redeemAmount != 0) {
+            revert IBurnRedeemCoreV2.InvalidRedeemAmount();
+        }
+    }
+
+    /**
+     * Helper to set top level properties for a burn redeem
+     */
+    function _setParameters(IBurnRedeemCoreV2.BurnRedeem storage burnRedeemInstance, IBurnRedeemCoreV2.BurnRedeemParameters calldata burnRedeemParameters) private {
+        burnRedeemInstance.startDate = burnRedeemParameters.startDate;
+        burnRedeemInstance.endDate = burnRedeemParameters.endDate;
+        burnRedeemInstance.redeemAmount = burnRedeemParameters.redeemAmount;
+        burnRedeemInstance.totalSupply = burnRedeemParameters.totalSupply;
+        burnRedeemInstance.storageProtocol = burnRedeemParameters.storageProtocol;
+        burnRedeemInstance.location = burnRedeemParameters.location;
+        burnRedeemInstance.cost = burnRedeemParameters.cost;
+        burnRedeemInstance.paymentReceiver = burnRedeemParameters.paymentReceiver;
+    }
+
+    /**
+     * Helper to set the burn groups for a burn redeem
+     */
+    function _setBurnGroups(IBurnRedeemCoreV2.BurnRedeem storage burnRedeemInstance, IBurnRedeemCoreV2.BurnGroup[] calldata burnGroups) private {
+        delete burnRedeemInstance.burnSet;
+        for (uint256 i; i < burnGroups.length;) {
+            burnRedeemInstance.burnSet.push();
+            IBurnRedeemCoreV2.BurnGroup storage burnGroup = burnRedeemInstance.burnSet[i];
+            if (burnGroups[i].requiredCount == 0 || burnGroups[i].requiredCount > burnGroups[i].items.length) {
+                revert InvalidInput();
+            }
+            burnGroup.requiredCount = burnGroups[i].requiredCount;
+            for (uint256 j; j < burnGroups[i].items.length;) {
+                IBurnRedeemCoreV2.BurnItem memory burnItem = burnGroups[i].items[j];
+                IBurnRedeemCoreV2.TokenSpec tokenSpec = burnItem.tokenSpec;
+                uint256 amount = burnItem.amount;
+                if (
+                    !(
+                        (tokenSpec == IBurnRedeemCoreV2.TokenSpec.ERC1155 && amount > 0) ||
+                        (tokenSpec == IBurnRedeemCoreV2.TokenSpec.ERC721 && amount == 0)
+                    ) || 
+                    burnItem.validationType == IBurnRedeemCoreV2.ValidationType.INVALID
+                ) {
+                    revert InvalidInput();
+                }
+                burnGroup.items.push(burnGroups[i].items[j]);
+                unchecked { ++j; }
+            }
+            unchecked { ++i; }
+        }
+    }
+
+}

--- a/packages/manifold/contracts/burnredeemUpdatableFee/ERC1155BurnRedeemV2.sol
+++ b/packages/manifold/contracts/burnredeemUpdatableFee/ERC1155BurnRedeemV2.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@manifoldxyz/creator-core-solidity/contracts/core/IERC1155CreatorCore.sol";
+
+import "./BurnRedeemCoreV2.sol";
+import "./BurnRedeemLibV2.sol";
+import "./IERC1155BurnRedeemV2.sol";
+
+contract ERC1155BurnRedeemV2 is BurnRedeemCoreV2, IERC1155BurnRedeemV2 {
+    using Strings for uint256;
+
+    // { creatorContractAddress => { instanceId =>  tokenId } }
+    mapping(address => mapping(uint256 => uint256)) private _redeemTokenIds;
+    // { creatorContractAddress => { tokenId =>  instanceId } }
+    mapping(address => mapping(uint256 => uint256)) private _redeemInstanceIds;
+
+    constructor(address initialOwner) BurnRedeemCoreV2(initialOwner) {}
+
+    function supportsInterface(bytes4 interfaceId) public view virtual override(BurnRedeemCoreV2, IERC165) returns (bool) {
+        return interfaceId == type(IERC1155BurnRedeemV2).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    /**
+     * See {IERC1155BurnRedeemV2-initializeBurnRedeem}.
+     */
+    function initializeBurnRedeem(
+        address creatorContractAddress,
+        uint256 instanceId,
+        BurnRedeemParameters calldata burnRedeemParameters
+    ) external override {
+        _validateAdmin(creatorContractAddress);
+        _initialize(creatorContractAddress, 0, instanceId, burnRedeemParameters);
+
+        // Mint a new token with amount '0' to the creator
+        address[] memory receivers = new address[](1);
+        receivers[0] = msg.sender;
+        string[] memory uris = new string[](1);
+        uint256[] memory amounts = new uint256[](1);
+        uint256[] memory newTokenIds = IERC1155CreatorCore(creatorContractAddress).mintExtensionNew(receivers, amounts, uris);
+        _redeemTokenIds[creatorContractAddress][instanceId] = newTokenIds[0];
+        _redeemInstanceIds[creatorContractAddress][newTokenIds[0]] = instanceId;
+    }
+
+    /**
+     * See {IERC1155BurnRedeemV2-updateBurnRedeem}.
+     */
+    function updateBurnRedeem(
+        address creatorContractAddress,
+        uint256 instanceId,
+        BurnRedeemParameters calldata burnRedeemParameters
+    ) external override {
+        _validateAdmin(creatorContractAddress);
+        _update(creatorContractAddress, instanceId, burnRedeemParameters);
+    }
+
+    /**
+     * See {IERC1155BurnRedeemV2-updateURI}.
+     */
+    function updateURI(
+        address creatorContractAddress,
+        uint256 instanceId,
+        StorageProtocol storageProtocol,
+        string calldata location
+    ) external override {
+        _validateAdmin(creatorContractAddress);
+        BurnRedeem storage burnRedeemInstance = _getBurnRedeem(creatorContractAddress, instanceId);
+        burnRedeemInstance.storageProtocol = storageProtocol;
+        burnRedeemInstance.location = location;
+        emit BurnRedeemLibV2.BurnRedeemUpdated(creatorContractAddress, instanceId);
+    }
+
+    /**
+     * Helper to mint multiple redeem tokens
+     */
+    function _redeem(address creatorContractAddress, uint256 instanceId, BurnRedeem storage burnRedeemInstance, address to, uint32 count, bytes memory data) internal override {
+        address[] memory addresses = new address[](1);
+        addresses[0] = to;
+        uint256[] memory tokenIds = new uint256[](1);
+        tokenIds[0] = _redeemTokenIds[creatorContractAddress][instanceId];
+        uint256[] memory values = new uint256[](1);
+        values[0] = burnRedeemInstance.redeemAmount * count;
+        
+        IERC1155CreatorCore(creatorContractAddress).mintExtensionExisting(addresses, tokenIds, values);
+        burnRedeemInstance.redeemedCount += uint32(values[0]);
+
+        emit BurnRedeemLibV2.BurnRedeemMint(creatorContractAddress, instanceId, tokenIds[0], uint32(values[0]), data);
+    }
+
+    /**
+     * See {ICreatorExtensionTokenURI-tokenURI}.
+     */
+    function tokenURI(address creatorContractAddress, uint256 tokenId) external override view returns(string memory uri) {
+        uint256 instanceId = _getRedeemInstanceId(creatorContractAddress, tokenId);
+        BurnRedeem memory burnRedeem = _burnRedeems[creatorContractAddress][instanceId];
+
+        string memory prefix = "";
+        if (burnRedeem.storageProtocol == StorageProtocol.ARWEAVE) {
+            prefix = ARWEAVE_PREFIX;
+        } else if (burnRedeem.storageProtocol == StorageProtocol.IPFS) {
+            prefix = IPFS_PREFIX;
+        }
+        uri = string(abi.encodePacked(prefix, burnRedeem.location));
+    }
+
+    /**
+     * See {IBurnRedeemCoreV2-getBurnRedeemForToken}.
+     */
+    function getBurnRedeemForToken(address creatorContractAddress, uint256 tokenId) external override view returns(uint256 instanceId, BurnRedeem memory burnRedeem) {
+        instanceId = _getRedeemInstanceId(creatorContractAddress, tokenId);
+        burnRedeem = _burnRedeems[creatorContractAddress][instanceId];
+    }
+
+    /**
+     * See {IBurnRedeemCoreV2-getBurnRedeemToken}.
+     */
+    function getBurnRedeemToken(address creatorContractAddress, uint256 instanceId) external override view returns(uint256 tokenId) {
+        tokenId = _redeemTokenIds[creatorContractAddress][instanceId];
+        if (tokenId == 0) {
+            revert BurnRedeemDoesNotExist(instanceId);
+        }
+    }
+
+    function _getRedeemInstanceId(address creatorContractAddress, uint256 tokenId) internal view returns(uint256 instanceId) {
+        instanceId = _redeemInstanceIds[creatorContractAddress][tokenId];
+        if (instanceId == 0) {
+            revert InvalidToken(tokenId);
+        }
+    }
+}

--- a/packages/manifold/contracts/burnredeemUpdatableFee/ERC721BurnRedeemV2.sol
+++ b/packages/manifold/contracts/burnredeemUpdatableFee/ERC721BurnRedeemV2.sol
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/// @author: manifold.xyz
+
+import "@manifoldxyz/creator-core-solidity/contracts/core/IERC721CreatorCore.sol";
+
+import "./BurnRedeemCoreV2.sol";
+import "./BurnRedeemLibV2.sol";
+import "./IERC721BurnRedeemV2.sol";
+import "../libraries/IERC721CreatorCoreVersion.sol";
+
+contract ERC721BurnRedeemV2 is BurnRedeemCoreV2, IERC721BurnRedeemV2 {
+    using Strings for uint256;
+
+    // NOTE: Only used for creatorContract versions < 3
+    // { contractAddress => { tokenId => { RedeemToken } }
+    mapping(address => mapping(uint256 => RedeemToken)) internal _redeemTokens;
+
+    // { creatorContractAddress => { instanceId =>  bool } }
+    mapping(address => mapping(uint256 => bool)) private _identicalTokenURI;
+
+    constructor(address initialOwner) BurnRedeemCoreV2(initialOwner) {}
+
+    function supportsInterface(bytes4 interfaceId) public view virtual override(BurnRedeemCoreV2, IERC165) returns (bool) {
+        return interfaceId == type(IERC721BurnRedeemV2).interfaceId || super.supportsInterface(interfaceId);
+    }
+    
+    /**
+     * @dev See {IERC721BurnRedeemV2-initializeBurnRedeem}.
+     */
+    function initializeBurnRedeem(
+        address creatorContractAddress,
+        uint256 instanceId,
+        BurnRedeemParameters calldata burnRedeemParameters,
+        bool identicalTokenURI
+    ) external  {
+        _validateAdmin(creatorContractAddress);
+        // Max uint56 for instanceId
+        if (instanceId == 0 || instanceId > MAX_UINT_56) {
+            revert InvalidInput();
+        }
+
+        uint8 creatorContractVersion;
+        try IERC721CreatorCoreVersion(creatorContractAddress).VERSION() returns(uint256 version) {
+            if (version > 255) {
+                revert UnsupportedContractVersion();
+            }
+            creatorContractVersion = uint8(version);
+        } catch {}
+        _initialize(creatorContractAddress, creatorContractVersion, instanceId, burnRedeemParameters);
+        _identicalTokenURI[creatorContractAddress][instanceId] = identicalTokenURI;
+    }
+
+    /**
+     * @dev See {IERC721BurnRedeemV2-updateBurnRedeem}.
+     */
+    function updateBurnRedeem(
+        address creatorContractAddress,
+        uint256 instanceId,
+        BurnRedeemParameters calldata burnRedeemParameters,
+        bool identicalTokenURI
+    ) external {
+        _validateAdmin(creatorContractAddress);
+        _update(creatorContractAddress, instanceId, burnRedeemParameters);
+        _identicalTokenURI[creatorContractAddress][instanceId] = identicalTokenURI;
+    }
+
+    /**
+     * See {IERC721BurnRedeemV2-updateTokenURI}.
+     */
+    function updateTokenURI(
+        address creatorContractAddress,
+        uint256 instanceId,
+        StorageProtocol storageProtocol,
+        string calldata location,
+        bool identicalTokenURI
+    ) external override  {
+        _validateAdmin(creatorContractAddress);
+        BurnRedeem storage burnRedeemInstance = _getBurnRedeem(creatorContractAddress, instanceId);
+        burnRedeemInstance.storageProtocol = storageProtocol;
+        burnRedeemInstance.location = location;
+        _identicalTokenURI[creatorContractAddress][instanceId] = identicalTokenURI;
+        emit BurnRedeemLibV2.BurnRedeemUpdated(creatorContractAddress, instanceId);
+    }
+
+    /** 
+     * Helper to mint multiple redeem tokens
+     */
+    function _redeem(address creatorContractAddress, uint256 instanceId, BurnRedeem storage burnRedeemInstance, address to, uint32 count, bytes memory data) internal override {
+        if (burnRedeemInstance.redeemAmount == 1 && count == 1) {
+            ++burnRedeemInstance.redeemedCount;
+            uint256 newTokenId;
+            if (burnRedeemInstance.contractVersion >= 3) {
+                uint80 tokenData = uint56(instanceId) << 24 | burnRedeemInstance.redeemedCount;
+                newTokenId = IERC721CreatorCore(creatorContractAddress).mintExtension(to, tokenData);
+            } else {
+                newTokenId = IERC721CreatorCore(creatorContractAddress).mintExtension(to);
+                _redeemTokens[creatorContractAddress][newTokenId] = RedeemToken(uint224(instanceId), burnRedeemInstance.redeemedCount);
+            }
+            emit BurnRedeemLibV2.BurnRedeemMint(creatorContractAddress, instanceId, newTokenId, 1, data);
+        } else {
+            uint256 totalCount = burnRedeemInstance.redeemAmount * count;
+            if (totalCount > MAX_UINT_16) {
+                revert InvalidInput();
+            }
+            uint256 startingCount = burnRedeemInstance.redeemedCount + 1;
+            burnRedeemInstance.redeemedCount += uint32(totalCount);
+            if (burnRedeemInstance.contractVersion >= 3) {
+                uint80[] memory tokenDatas = new uint80[](totalCount);
+                for (uint256 i; i < totalCount;) {
+                    tokenDatas[i] = uint56(instanceId) << 24 | uint24(startingCount+i);
+                    unchecked { ++i; }
+                }
+                uint256[] memory newTokenIds = IERC721CreatorCore(creatorContractAddress).mintExtensionBatch(to, tokenDatas);
+                for (uint256 i; i < totalCount;) {
+                    emit BurnRedeemLibV2.BurnRedeemMint(creatorContractAddress, instanceId, newTokenIds[i], 1, data);
+                    unchecked { i++; }
+                }
+            } else {
+                uint256[] memory newTokenIds = IERC721CreatorCore(creatorContractAddress).mintExtensionBatch(to, uint16(totalCount));
+                for (uint256 i; i < totalCount;) {
+                    _redeemTokens[creatorContractAddress][newTokenIds[i]] = RedeemToken(uint224(instanceId), uint32(startingCount + i));
+                    emit BurnRedeemLibV2.BurnRedeemMint(creatorContractAddress, instanceId, newTokenIds[i], 1, data);
+                    unchecked { i++; }
+                }
+            }
+        }
+    }
+
+    /**
+     * See {ICreatorExtensionTokenURI-tokenURI}.
+     */
+    function tokenURI(address creatorContractAddress, uint256 tokenId) external override view returns(string memory uri) {
+        (uint256 instanceId, uint256 mintNumber) = _getInstanceIdAndMintNumber(creatorContractAddress, tokenId);
+        BurnRedeem memory burnRedeem = _burnRedeems[creatorContractAddress][instanceId];
+
+        string memory prefix = "";
+        if (burnRedeem.storageProtocol == StorageProtocol.ARWEAVE) {
+            prefix = ARWEAVE_PREFIX;
+        } else if (burnRedeem.storageProtocol == StorageProtocol.IPFS) {
+            prefix = IPFS_PREFIX;
+        }
+        uri = string(abi.encodePacked(prefix, burnRedeem.location));
+
+        if (!_identicalTokenURI[creatorContractAddress][instanceId]) {
+            uri = string(abi.encodePacked(uri, "/", uint256(mintNumber).toString()));
+        }
+    }
+
+    /**
+     * See {IBurnRedeemCoreV2-getBurnRedeemForToken}.
+     */
+    function getBurnRedeemForToken(address creatorContractAddress, uint256 tokenId) external override view returns(uint256 instanceId, BurnRedeem memory burnRedeem) {
+        (instanceId, ) = _getInstanceIdAndMintNumber(creatorContractAddress, tokenId);
+        burnRedeem = _burnRedeems[creatorContractAddress][instanceId];
+    }
+
+    function _getInstanceIdAndMintNumber(address creatorContractAddress, uint256 tokenId) internal view returns(uint256 instanceId, uint256 mintNumber) {
+        RedeemToken memory token = _redeemTokens[creatorContractAddress][tokenId];
+        if (token.instanceId == 0) {
+            // No claim, try to retrieve from tokenData
+            uint80 tokenData = IERC721CreatorCore(creatorContractAddress).tokenData(tokenId);
+            instanceId = uint56(tokenData >> 24);
+            if (instanceId == 0) {
+                revert InvalidToken(tokenId);
+            }
+            mintNumber = uint24(tokenData & MAX_UINT_24);
+        } else {
+            instanceId = token.instanceId;
+            mintNumber = token.mintNumber;
+        }
+    }
+}

--- a/packages/manifold/contracts/burnredeemUpdatableFee/IBurnRedeemCoreV2.sol
+++ b/packages/manifold/contracts/burnredeemUpdatableFee/IBurnRedeemCoreV2.sol
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/// @author: manifold.xyz
+
+import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+/**
+ * Burn Redeem Core interface
+ */
+interface IBurnRedeemCoreV2 is IERC165, IERC721Receiver, IERC1155Receiver  {
+    error NotAdmin(address);
+    error UnsupportedContractVersion();
+    error InvalidToken(uint256);
+    error InvalidInput();
+    error InvalidTokenSpec();
+    error InvalidBurnSpec();
+    error InvalidData();
+    error TransferFailure();
+    
+    error BurnRedeemDoesNotExist(uint256);
+    error BurnRedeemInactive(uint256);
+
+    error InvalidBurnAmount();
+    error InvalidRedeemAmount();
+    error InvalidPaymentAmount();
+
+    error Inactive();
+
+
+    enum StorageProtocol { INVALID, NONE, ARWEAVE, IPFS }
+
+    /**
+     * @notice the validation type used for a `BurnItem`
+     * CONTRACT                 any token from a specific contract is valid
+     * RANGE                    token IDs within a range (inclusive) are valid
+     * MERKLE_TREE              various individual token IDs included in a merkle tree are valid
+     * ANY                      any token from any contract
+     */
+    enum ValidationType { INVALID, CONTRACT, RANGE, MERKLE_TREE, ANY }
+
+    enum TokenSpec { INVALID, ERC721, ERC1155 }
+    enum BurnSpec { NONE, MANIFOLD, OPENZEPPELIN }
+
+    /**
+     * @notice a `BurnItem` indicates which tokens are eligible to be burned
+     * @param validationType    which type of validation used to check that the burn item is 
+     *                          satisfied
+     * @param tokenSpec         whether the token is an ERC721 or ERC1155
+     * @param burnSpec          whether the contract for a token has a `burn` function and, if so,
+     *                          what interface
+     * @param amount            (only for ERC1155 tokens) the amount (value) required to burn
+     * @param minTokenId        (only for RANGE validation) the minimum valid token ID
+     * @param maxTokenId        (only for RANGE validation) the maximum valid token ID
+     * @param merkleRoot        (only for MERKLE_TREE validation) the root of the merkle tree of
+     *                          valid token IDs
+     */
+    struct BurnItem {
+        ValidationType validationType;
+        address contractAddress;
+        TokenSpec tokenSpec;
+        BurnSpec burnSpec;
+        uint72 amount;
+        uint256 minTokenId;
+        uint256 maxTokenId;
+        bytes32 merkleRoot;
+    }
+
+    /**
+     * @notice a `BurnGroup` is a group of valid `BurnItem`s
+     * @param requiredCount     the number of `BurnItem`s (0 < requiredCount <= items.length) that 
+     *                          need to be included in a burn
+     * @param items             the list of `BurnItem`s
+     */
+    struct BurnGroup {
+        uint256 requiredCount;
+        BurnItem[] items;
+    }
+
+    /**
+     * @notice parameters for burn redeem intialization/updates
+     * @param paymentReceiver   the address to forward proceeds from paid burn redeems
+     * @param storageProtocol   the type of storage used for the redeem token URIs
+     * @param redeemAmount      the number of redeem tokens to mint for each burn redeem
+     * @param totalSupply       the maximum number of redeem tokens to mint (0 for unlimited)
+     * @param startDate         the starting time for the burn redeem (0 for immediately)
+     * @param endDate           the end time for the burn redeem (0 for never)
+     * @param cost              the cost for each burn redeem
+     * @param location          used to construct the token URI (Arweave hash, full URI, etc.)
+     * @param burnSet           a list of `BurnGroup`s that must each be satisfied for a burn redeem
+     */
+    struct BurnRedeemParameters {
+        address payable paymentReceiver;
+        StorageProtocol storageProtocol;
+        uint16 redeemAmount;
+        uint32 totalSupply;
+        uint48 startDate;
+        uint48 endDate;
+        uint160 cost;
+        string location;
+        BurnGroup[] burnSet;
+    }
+
+    struct BurnRedeem {
+        address payable paymentReceiver;
+        StorageProtocol storageProtocol;
+        uint32 redeemedCount;
+        uint16 redeemAmount;
+        uint32 totalSupply;
+        uint8 contractVersion;
+        uint48 startDate;
+        uint48 endDate;
+        uint160 cost;
+        string location;
+        BurnGroup[] burnSet;
+    }
+
+    /**
+     * @notice a pointer to a `BurnItem` in a `BurnGroup` used in calls to `burnRedeem`
+     * @param groupIndex        the index of the `BurnGroup` in `BurnRedeem.burnSet`
+     * @param itemIndex         the index of the `BurnItem` in `BurnGroup.items`
+     * @param contractAddress   the address of the contract for the token
+     * @param id                the token ID
+     * @param merkleProof       the merkle proof for the token ID (only for MERKLE_TREE validation)
+     */
+    struct BurnToken {
+        uint48 groupIndex;
+        uint48 itemIndex;
+        address contractAddress;
+        uint256 id;
+        bytes32[] merkleProof;
+    }
+
+    /**
+     * @notice get a burn redeem corresponding to a creator contract and instanceId
+     * @param creatorContractAddress    the address of the creator contract
+     * @param instanceId                the instanceId of the burn redeem for the creator contract
+     * @return BurnRedeem               the burn redeem object
+     */
+    function getBurnRedeem(address creatorContractAddress, uint256 instanceId) external view returns(BurnRedeem memory);
+    
+    /**
+     * @notice get a burn redeem corresponding to a creator contract and tokenId
+     * @param creatorContractAddress    the address of the creator contract
+     * @param tokenId                   the token to retrieve the burn redeem for
+     * @return                          the burn redeem instanceId and burn redeem object
+     */
+    function getBurnRedeemForToken(address creatorContractAddress, uint256 tokenId) external view returns(uint256, BurnRedeem memory);
+
+    /**
+     * @notice burn tokens and mint a redeem token
+     * @param creatorContractAddress    the address of the creator contract
+     * @param instanceId                the instanceId of the burn redeem for the creator contract
+     * @param burnRedeemCount           the number of burn redeems we want to do
+     * @param burnTokens                the tokens to burn with pointers to the corresponding BurnItem requirement
+     */
+    function burnRedeem(address creatorContractAddress, uint256 instanceId, uint32 burnRedeemCount, BurnToken[] calldata burnTokens) external payable;
+
+    /**
+     * @notice burn tokens and mint redeem tokens multiple times in a single transaction
+     * @param creatorContractAddresses  the addresses of the creator contracts
+     * @param instanceIds               the instanceIds of the burn redeems for the corresponding creator contract
+     * @param burnRedeemCounts          the burn redeem counts for each burn
+     * @param burnTokens                the tokens to burn for each burn redeem with pointers to the corresponding BurnItem requirement
+     */
+    function burnRedeem(address[] calldata creatorContractAddresses, uint256[] calldata instanceIds, uint32[] calldata burnRedeemCounts, BurnToken[][] calldata burnTokens) external payable;
+
+    /**
+     * @notice burn tokens and mint a redeem token
+     * @param creatorContractAddress    the address of the creator contract
+     * @param instanceId                the instanceId of the burn redeem for the creator contract
+     * @param burnRedeemCount           the number of burn redeems we want to do
+     * @param burnTokens                the tokens to burn with pointers to the corresponding BurnItem requirement
+     * @param data                      the data to emit with the BurnRedeemMint event
+     */
+    function burnRedeemWithData(address creatorContractAddress, uint256 instanceId, uint32 burnRedeemCount, BurnToken[] calldata burnTokens, bytes calldata data) external payable;
+
+    /**
+     * @notice allow admin to airdrop arbitrary tokens 
+     * @param creatorContractAddress    the creator contract to mint tokens for
+     * @param instanceId                the instanceId of the burn redeem for the creator contract
+     * @param recipients                addresses to airdrop to
+     * @param amounts                   number of redeems to perform for each address in recipients
+     */
+    function airdrop(address creatorContractAddress, uint256 instanceId, address[] calldata recipients, uint32[] calldata amounts) external;
+
+    /**
+     * @notice recover a token that was sent to the contract without safeTransferFrom
+     * @param tokenAddress              the address of the token contract
+     * @param tokenId                   the id of the token
+     * @param destination               the address to send the token to
+     */
+    function recoverERC721(address tokenAddress, uint256 tokenId, address destination) external;
+
+    /**
+     * @notice withdraw Manifold fee proceeds from the contract
+     * @param recipient                 recepient of the funds
+     * @param amount                    amount to withdraw in Wei
+     */
+    function withdraw(address payable recipient, uint256 amount) external;
+
+    /**
+     * @notice set the Manifold Membership contract address
+     * @param addr                      the address of the Manifold Membership contract 
+     */
+    function setMembershipAddress(address addr) external;
+
+    /**
+     * @notice set the burn fees
+     * @param burnFee                     the burn fee
+     * @param multiBurnFee                 the multi burn fee
+     */
+    function setBurnFees(uint256 burnFee, uint256 multiBurnFee) external;
+
+    /**
+     * @notice set the active status of the burn redeem
+     * @param _active                    the active status
+     */
+    function setActive(bool _active) external;
+}

--- a/packages/manifold/contracts/burnredeemUpdatableFee/IERC1155BurnRedeemV2.sol
+++ b/packages/manifold/contracts/burnredeemUpdatableFee/IERC1155BurnRedeemV2.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/// @author: manifold.xyz
+
+import "./IBurnRedeemCoreV2.sol";
+
+interface IERC1155BurnRedeemV2 is IBurnRedeemCoreV2 {
+    struct ExtendedConfig {
+        uint256 redeemTokenId;
+    }
+
+    /**
+     * @notice initialize a new burn redeem, emit initialize event
+     * @param creatorContractAddress    the creator contract the burn will mint redeem tokens for
+     * @param instanceId                the instanceId of the burnRedeem for the creator contract
+     * @param burnRedeemParameters      the parameters which will affect the minting behavior of the burn redeem
+     */
+    function initializeBurnRedeem(address creatorContractAddress, uint256 instanceId, BurnRedeemParameters calldata burnRedeemParameters) external;
+
+    /**
+     * @notice update an existing burn redeem
+     * @param creatorContractAddress    the creator contract corresponding to the burn redeem
+     * @param instanceId                the instanceId of the burnRedeem for the creator contract
+     * @param burnRedeemParameters      the parameters which will affect the minting behavior of the burn redeem
+     */
+    function updateBurnRedeem(address creatorContractAddress, uint256 instanceId, BurnRedeemParameters calldata burnRedeemParameters) external;
+
+    /**
+     * @notice update an existing burn redeem
+     * @param creatorContractAddress    the creator contract corresponding to the burn redeem
+     * @param instanceId                the instanceId of the burnRedeem for the creator contract
+     * @param storageProtocol           the storage protocol for the metadata
+     * @param location                  the location of the metadata
+     */
+    function updateURI(address creatorContractAddress, uint256 instanceId, StorageProtocol storageProtocol, string calldata location) external;
+
+    /**
+     * @notice get the redeem token ID for a burn redeem
+     */
+    function getBurnRedeemToken(address creatorContractAddress, uint256 instanceId) external view returns (uint256);
+}

--- a/packages/manifold/contracts/burnredeemUpdatableFee/IERC721BurnRedeemV2.sol
+++ b/packages/manifold/contracts/burnredeemUpdatableFee/IERC721BurnRedeemV2.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/// @author: manifold.xyz
+
+import "./IBurnRedeemCoreV2.sol";
+
+interface IERC721BurnRedeemV2 is IBurnRedeemCoreV2 {
+    struct RedeemToken {
+        uint224 instanceId;
+        uint32 mintNumber;
+    }
+
+    /**
+     * @notice initialize a new burn redeem, emit initialize event
+     * @param creatorContractAddress    the creator contract the burn will mint redeem tokens for
+     * @param instanceId                the instanceId of the burnRedeem for the creator contract
+     * @param burnRedeemParameters      the parameters which will affect the minting behavior of the burn redeem
+     * @param identicalTokenURI         whether or not the tokenURI is identical
+     */
+    function initializeBurnRedeem(address creatorContractAddress, uint256 instanceId, BurnRedeemParameters calldata burnRedeemParameters, bool identicalTokenURI) external;
+
+    /**
+     * @notice update an existing burn redeem
+     * @param creatorContractAddress    the creator contract corresponding to the burn redeem
+     * @param instanceId                the instanceId of the burnRedeem for the creator contract
+     * @param burnRedeemParameters      the parameters which will affect the minting behavior of the burn redeem
+     * @param identicalTokenURI         whether or not the tokenURI is identical
+     */
+    function updateBurnRedeem(address creatorContractAddress, uint256 instanceId, BurnRedeemParameters calldata burnRedeemParameters, bool identicalTokenURI) external;
+
+    /**
+     * @notice update an existing burn redeem
+     * @param creatorContractAddress    the creator contract corresponding to the burn redeem
+     * @param instanceId                the instanceId of the burnRedeem for the creator contract
+     * @param storageProtocol           the storage protocol for the metadata
+     * @param location                  the location of the metadata
+     * @param identicalTokenURI         whether or not the URI's are supposed to be identical
+     */
+    function updateTokenURI(address creatorContractAddress, uint256 instanceId, StorageProtocol storageProtocol, string calldata location, bool identicalTokenURI) external;
+}

--- a/packages/manifold/contracts/burnredeemUpdatableFee/Interfaces.sol
+++ b/packages/manifold/contracts/burnredeemUpdatableFee/Interfaces.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+interface Burnable721 {
+    function burn(uint256 tokenId) external;
+}
+
+interface OZBurnable1155 {
+    function burn(address account, uint256 id, uint256 value) external;
+}
+
+interface Manifold1155 {
+    function burn(address account, uint256[] memory tokenIds, uint256[] memory amounts) external;
+}

--- a/packages/manifold/script/BurnRedeemLibV2.s.sol
+++ b/packages/manifold/script/BurnRedeemLibV2.s.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Script.sol";
+import "../contracts/burnredeemUpdatableFee/BurnRedeemLibV2.sol";
+
+contract DeployBurnRedeemLibV2 is Script {
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+        // Deploy using the create2 proxy @ 0x4e59b44847b379578588920cA78FbF26c0B4956C
+        // With the calldata being the salt + bytecode
+        // Deploy with 150 runs
+        // e.g.
+        //   forge script scripts/BurnRedeemLib.s.sol --optimizer-runs 150 --rpc-url <YOUR_NODE> --broadcast
+        //   forge verify-contract --compiler-version 0.8.17 --optimizer-runs 150 --chain goerli <DEPLOYED_ADDRESS> contracts/burnredeem/BurnRedeemLib.sol:BurnRedeemLib --watch
+        0x4e59b44847b379578588920cA78FbF26c0B4956C.call(abi.encodePacked(bytes32(0x4275726e52656465656d4c69624275726e52656465656d4c69624275726e5265), vm.getCode("BurnRedeemLibV2")));
+        vm.stopBroadcast();
+    }
+}

--- a/packages/manifold/script/BurnRedeemLibV2.s.sol
+++ b/packages/manifold/script/BurnRedeemLibV2.s.sol
@@ -12,9 +12,9 @@ contract DeployBurnRedeemLibV2 is Script {
         // With the calldata being the salt + bytecode
         // Deploy with 150 runs
         // e.g.
-        //   forge script scripts/BurnRedeemLib.s.sol --optimizer-runs 150 --rpc-url <YOUR_NODE> --broadcast
+        //   forge script script/BurnRedeemLib2.s.sol --optimizer-runs 150 --rpc-url <YOUR_NODE> --broadcast
         //   forge verify-contract --compiler-version 0.8.17 --optimizer-runs 150 --chain goerli <DEPLOYED_ADDRESS> contracts/burnredeem/BurnRedeemLib.sol:BurnRedeemLib --watch
-        0x4e59b44847b379578588920cA78FbF26c0B4956C.call(abi.encodePacked(bytes32(0x4275726e52656465656d4c69624275726e52656465656d4c69624275726e5265), vm.getCode("BurnRedeemLibV2")));
+        0x4e59b44847b379578588920cA78FbF26c0B4956C.call(abi.encodePacked(bytes32(0x4275726e52656465656d4c69624275726e52656465656d4c69624275726e5265), vm.getCode("BurnRedeemLibV2.sol:BurnRedeemLibV2")));
         vm.stopBroadcast();
     }
 }

--- a/packages/manifold/script/BurnRedeemLibV2.s.sol
+++ b/packages/manifold/script/BurnRedeemLibV2.s.sol
@@ -5,16 +5,21 @@ import "forge-std/Script.sol";
 import "../contracts/burnredeemUpdatableFee/BurnRedeemLibV2.sol";
 
 contract DeployBurnRedeemLibV2 is Script {
-    function run() external {
-        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-        vm.startBroadcast(deployerPrivateKey);
-        // Deploy using the create2 proxy @ 0x4e59b44847b379578588920cA78FbF26c0B4956C
-        // With the calldata being the salt + bytecode
-        // Deploy with 150 runs
-        // e.g.
-        //   forge script script/BurnRedeemLib2.s.sol --optimizer-runs 150 --rpc-url <YOUR_NODE> --broadcast
-        //   forge verify-contract --compiler-version 0.8.17 --optimizer-runs 150 --chain goerli <DEPLOYED_ADDRESS> contracts/burnredeem/BurnRedeemLib.sol:BurnRedeemLib --watch
-        0x4e59b44847b379578588920cA78FbF26c0B4956C.call(abi.encodePacked(bytes32(0x4275726e52656465656d4c69624275726e52656465656d4c69624275726e5265), vm.getCode("BurnRedeemLibV2.sol:BurnRedeemLibV2")));
-        vm.stopBroadcast();
-    }
+  function run() external {
+    uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+    vm.startBroadcast(deployerPrivateKey);
+    // Deploy using the create2 proxy @ 0x4e59b44847b379578588920cA78FbF26c0B4956C
+    // With the calldata being the salt + bytecode
+    // Deploy with 150 runs
+    // e.g.
+    //   forge script script/BurnRedeemLibV2.s.sol --optimizer-runs 150 --rpc-url <YOUR_NODE> --broadcast
+    //   forge verify-contract --compiler-version 0.8.17 --optimizer-runs 150 --chain goerli <DEPLOYED_ADDRESS> contracts/burnredeemUpdatableFee/BurnRedeemLibV2.sol:BurnRedeemLibV2 --watch
+    0x4e59b44847b379578588920cA78FbF26c0B4956C.call(
+      abi.encodePacked(
+        bytes32(0x4275726e52656465656d4c69624275726e52656465656d4c69624275726e5265),
+        vm.getCode("BurnRedeemLibV2.sol:BurnRedeemLibV2")
+      )
+    );
+    vm.stopBroadcast();
+  }
 }

--- a/packages/manifold/script/ERC1155BurnRedeemV2.s.sol
+++ b/packages/manifold/script/ERC1155BurnRedeemV2.s.sol
@@ -5,18 +5,18 @@ import "forge-std/Script.sol";
 import "../contracts/burnredeemUpdatableFee/ERC1155BurnRedeemV2.sol";
 
 contract DeployERC1155BurnRedeemV2 is Script {
-    function run() external {
-        address initialOwner = vm.envAddress("INITIAL_OWNER");
-        require(initialOwner != address(0), "Initial owner address not set.  Please configure INITIAL_OWNER.");
+  function run() external {
+    address initialOwner = vm.envAddress("INITIAL_OWNER");
+    require(initialOwner != address(0), "Initial owner address not set.  Please configure INITIAL_OWNER.");
 
-        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-        vm.startBroadcast(deployerPrivateKey);
-        // Need to deploy the BurnRedeemLib first via BurnRedeemLib.s.sol
-        // Deploy by specifying the linked library address and at 150 runs (identical to linked library)
-        // e.g.
-        //   forge script script/ERC1155BurnRedeemV2.s.sol --optimizer-runs 150 --rpc-url <YOUR_NODE> --libraries contracts/burnredeemUpdatableFee/BurnRedeemLibV2.sol:BurnRedeemLibV2:<BURN_REDEEM_LIB_ADDRESS> --broadcast
-        //   forge verify-contract --compiler-version 0.8.17 --optimizer-runs 150 --chain goerli <DEPLOYED_ADDRESS> contracts/burnredeemUpdatableFee/ERC1155BurnRedeemV2.sol:ERC1155BurnRedeemV2 --libraries contracts/burnredeemUpdatableFee/BurnRedeemLibV2.sol:BurnRedeemLibV2:<BURN_REDEEM_LIB_ADDRESS> --constructor-args $(cast abi-encode "constructor(address)" "${INITIAL_OWNER}") --watch
-        new ERC1155BurnRedeemV2{salt: 0x455243313135354275726e52656465656d455243313135354275726e52656465}(initialOwner);
-        vm.stopBroadcast();
-    }
+    uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+    vm.startBroadcast(deployerPrivateKey);
+    // Need to deploy the BurnRedeemLibV2 first via BurnRedeemLibV2.s.sol
+    // Deploy by specifying the linked library address and at 150 runs (identical to linked library)
+    // e.g.
+    //   forge script script/ERC1155BurnRedeemV2.s.sol --optimizer-runs 150 --rpc-url <YOUR_NODE> --libraries contracts/burnredeemUpdatableFee/BurnRedeemLibV2.sol:BurnRedeemLibV2:<BURN_REDEEM_LIB_ADDRESS> --broadcast
+    //   forge verify-contract --compiler-version 0.8.17 --optimizer-runs 150 --chain goerli <DEPLOYED_ADDRESS> contracts/burnredeemUpdatableFee/ERC1155BurnRedeemV2.sol:ERC1155BurnRedeemV2 --libraries contracts/burnredeemUpdatableFee/BurnRedeemLibV2.sol:BurnRedeemLibV2:<BURN_REDEEM_LIB_ADDRESS> --constructor-args $(cast abi-encode "constructor(address)" "${INITIAL_OWNER}") --watch
+    new ERC1155BurnRedeemV2{ salt: 0x455243313135354275726e52656465656d455243313135354275726e52656465 }(initialOwner);
+    vm.stopBroadcast();
+  }
 }

--- a/packages/manifold/script/ERC1155BurnRedeemV2.s.sol
+++ b/packages/manifold/script/ERC1155BurnRedeemV2.s.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Script.sol";
+import "../contracts/burnredeemUpdatableFee/ERC1155BurnRedeemV2.sol";
+
+contract DeployERC1155BurnRedeemV2 is Script {
+    function run() external {
+        address initialOwner = vm.envAddress("INITIAL_OWNER");
+        require(initialOwner != address(0), "Initial owner address not set.  Please configure INITIAL_OWNER.");
+
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+        // Need to deploy the BurnRedeemLib first via BurnRedeemLib.s.sol
+        // Deploy by specifying the linked library address and at 150 runs (identical to linked library)
+        // e.g.
+        //   forge script script/ERC1155BurnRedeemV2.s.sol --optimizer-runs 150 --rpc-url <YOUR_NODE> --libraries contracts/burnredeemUpdatableFee/BurnRedeemLibV2.sol:BurnRedeemLibV2:<BURN_REDEEM_LIB_ADDRESS> --broadcast
+        //   forge verify-contract --compiler-version 0.8.17 --optimizer-runs 150 --chain goerli <DEPLOYED_ADDRESS> contracts/burnredeemUpdatableFee/ERC1155BurnRedeemV2.sol:ERC1155BurnRedeemV2 --libraries contracts/burnredeemUpdatableFee/BurnRedeemLibV2.sol:BurnRedeemLibV2:<BURN_REDEEM_LIB_ADDRESS> --constructor-args $(cast abi-encode "constructor(address)" "${INITIAL_OWNER}") --watch
+        new ERC1155BurnRedeemV2{salt: 0x455243313135354275726e52656465656d455243313135354275726e52656465}(initialOwner);
+        vm.stopBroadcast();
+    }
+}

--- a/packages/manifold/script/ERC721BurnRedeemV2.s.sol
+++ b/packages/manifold/script/ERC721BurnRedeemV2.s.sol
@@ -15,7 +15,7 @@ contract DeployERC721BurnRedeemV2 is Script {
     // Deploy by specifying the linked library address and at 150 runs (identical to linked library)
     // e.g.
     //   forge script script/ERC721BurnRedeemV2.s.sol --optimizer-runs 150 --rpc-url <YOUR_NODE> --libraries contracts/burnredeemUpdatableFee/BurnRedeemLibV2.sol:BurnRedeemLibV2:<BURN_REDEEM_LIB_ADDRESS> --broadcast
-    //   forge verify-contract --compiler-version 0.8.17 --optimizer-runs 150 --chain goerli <DEPLOYED_ADDRESS> contracts/burnredeemUpdatableFee/ERC721BurnRedeemV2.sol:ERC721BurnRedeemV2 --libraries contracts/burnredeemUpdatableFee/BurnRedeemLibV2.sol:BurnRedeemLibV2:<BURN_REDEEM_LIB_ADDRESS> --constructor-args $(cast abi-encode "constructor(address)" "${INITIAL_OWNER}") --watch
+    //   forge verify-contract --compiler-version 0.8.17 --optimizer-runs 150 --chain sepolia <DEPLOYED_ADDRESS> contracts/burnredeemUpdatableFee/ERC721BurnRedeemV2.sol:ERC721BurnRedeemV2 --libraries contracts/burnredeemUpdatableFee/BurnRedeemLibV2.sol:BurnRedeemLibV2:<BURN_REDEEM_LIB_ADDRESS> --constructor-args $(cast abi-encode "constructor(address)" "${INITIAL_OWNER}") --watch
     new ERC721BurnRedeemV2{ salt: 0x4552433732314275726e52656465656d4552433732314275726e52656465656d }(initialOwner);
     vm.stopBroadcast();
   }

--- a/packages/manifold/script/ERC721BurnRedeemV2.s.sol
+++ b/packages/manifold/script/ERC721BurnRedeemV2.s.sol
@@ -14,8 +14,8 @@ contract DeployERC721BurnRedeemV2 is Script {
     // Need to deploy the BurnRedeemLibV2 first via BurnRedeemLibV2.s.sol
     // Deploy by specifying the linked library address and at 150 runs (identical to linked library)
     // e.g.
-    //   forge script scripts/ERC721BurnRedeem.s.sol --optimizer-runs 150 --rpc-url <YOUR_NODE> --libraries contracts/burnredeem/BurnRedeemLib.sol:BurnRedeemLib:<BURN_REDEEM_LIB_ADDRESS> --broadcast
-    //   forge verify-contract --compiler-version 0.8.17 --optimizer-runs 150 --chain goerli <DEPLOYED_ADDRESS> contracts/burnredeem/ERC721BurnRedeem.sol:ERC721BurnRedeem --libraries contracts/burnredeem/BurnRedeemLib.sol:BurnRedeemLib:<BURN_REDEEM_LIB_ADDRESS> --constructor-args $(cast abi-encode "constructor(address)" "${INITIAL_OWNER}") --watch
+    //   forge script script/ERC721BurnRedeemV2.s.sol --optimizer-runs 150 --rpc-url <YOUR_NODE> --libraries contracts/burnredeemUpdatableFee/BurnRedeemLibV2.sol:BurnRedeemLibV2:<BURN_REDEEM_LIB_ADDRESS> --broadcast
+    //   forge verify-contract --compiler-version 0.8.17 --optimizer-runs 150 --chain goerli <DEPLOYED_ADDRESS> contracts/burnredeemUpdatableFee/ERC721BurnRedeemV2.sol:ERC721BurnRedeemV2 --libraries contracts/burnredeemUpdatableFee/BurnRedeemLibV2.sol:BurnRedeemLibV2:<BURN_REDEEM_LIB_ADDRESS> --constructor-args $(cast abi-encode "constructor(address)" "${INITIAL_OWNER}") --watch
     new ERC721BurnRedeemV2{ salt: 0x4552433732314275726e52656465656d4552433732314275726e52656465656d }(initialOwner);
     vm.stopBroadcast();
   }

--- a/packages/manifold/script/ERC721BurnRedeemV2.s.sol
+++ b/packages/manifold/script/ERC721BurnRedeemV2.s.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Script.sol";
+import "../contracts/burnredeemUpdatableFee/ERC721BurnRedeemV2.sol";
+
+contract DeployERC721BurnRedeemV2 is Script {
+  function run() external {
+    address initialOwner = vm.envAddress("INITIAL_OWNER");
+    require(initialOwner != address(0), "Initial owner address not set.  Please configure INITIAL_OWNER.");
+
+    uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+    vm.startBroadcast(deployerPrivateKey);
+    // Need to deploy the BurnRedeemLibV2 first via BurnRedeemLibV2.s.sol
+    // Deploy by specifying the linked library address and at 150 runs (identical to linked library)
+    // e.g.
+    //   forge script scripts/ERC721BurnRedeem.s.sol --optimizer-runs 150 --rpc-url <YOUR_NODE> --libraries contracts/burnredeem/BurnRedeemLib.sol:BurnRedeemLib:<BURN_REDEEM_LIB_ADDRESS> --broadcast
+    //   forge verify-contract --compiler-version 0.8.17 --optimizer-runs 150 --chain goerli <DEPLOYED_ADDRESS> contracts/burnredeem/ERC721BurnRedeem.sol:ERC721BurnRedeem --libraries contracts/burnredeem/BurnRedeemLib.sol:BurnRedeemLib:<BURN_REDEEM_LIB_ADDRESS> --constructor-args $(cast abi-encode "constructor(address)" "${INITIAL_OWNER}") --watch
+    new ERC721BurnRedeemV2{ salt: 0x4552433732314275726e52656465656d4552433732314275726e52656465656d }(initialOwner);
+    vm.stopBroadcast();
+  }
+}

--- a/packages/manifold/test/burnredeemUpdatableFee/ERC1155BurnRedeemV2.t.sol
+++ b/packages/manifold/test/burnredeemUpdatableFee/ERC1155BurnRedeemV2.t.sol
@@ -2,14 +2,14 @@
 pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
-import "../../contracts/burnredeem/ERC1155BurnRedeem.sol";
+import "../../contracts/burnredeemUpdatableFee/ERC1155BurnRedeemV2.sol";
 import "@manifoldxyz/creator-core-solidity/contracts/ERC721Creator.sol";
 import "@manifoldxyz/creator-core-solidity/contracts/ERC1155Creator.sol";
 
 import "../mocks/Mock.sol";
 
-contract ManifoldERC1155BurnRedeemTest is Test {
-    ERC1155BurnRedeem public burnRedeem;
+contract ManifoldERC1155BurnRedeemV2Test is Test {
+    ERC1155BurnRedeemV2 public burnRedeem;
     ERC1155Creator public creator;
     MockManifoldMembership public manifoldMembership;
     ERC721Creator public burnable721;
@@ -23,11 +23,13 @@ contract ManifoldERC1155BurnRedeemTest is Test {
     MockERC1155Fallback public fallback1155;
     MockERC1155FallbackBurnable public fallback1155Burnable;
 
+    uint256 public defaultBurnFee = 690000000000000;
+    uint256 public defaultMultiBurnFee = 990000000000000;
+
     address public owner = 0x6140F00e4Ff3936702E68744f2b5978885464cbB;
     address public burnRedeemOwner = 0xc78Dc443c126af6E4f6Ed540c1e740C1b5be09cd;
     address public anyone1 = 0x80AAC46bbd3C2FcE33681541a52CacBEd14bF425;
     address public anyone2 = 0x5174cD462b60c536eb51D4ceC1D561D3Ea31004F;
-
 
     address public zeroAddress = address(0);
     address public deadAddress = 0x000000000000000000000000000000000000dEaD;
@@ -35,7 +37,7 @@ contract ManifoldERC1155BurnRedeemTest is Test {
     function setUp() public {
         vm.startPrank(owner);
         creator = new ERC1155Creator("Test", "TEST");
-        burnRedeem = new ERC1155BurnRedeem(burnRedeemOwner);
+        burnRedeem = new ERC1155BurnRedeemV2(burnRedeemOwner);
         manifoldMembership = new MockManifoldMembership();
         burnable721 = new ERC721Creator("Test", "TEST");
         burnable721_2 = new ERC721Creator("Test", "TEST");
@@ -50,16 +52,18 @@ contract ManifoldERC1155BurnRedeemTest is Test {
         creator.registerExtension(address(burnRedeem), "");
         vm.stopPrank();
 
-        vm.prank(burnRedeemOwner);
+        vm.startPrank(burnRedeemOwner);
         burnRedeem.setMembershipAddress(address(manifoldMembership));
+        burnRedeem.setBurnFees(defaultBurnFee, defaultMultiBurnFee);
+        vm.stopPrank();
         vm.warp(100000);
     }
 
     function testAccess() public {
-        IBurnRedeemCore.BurnGroup[] memory group = new IBurnRedeemCore.BurnGroup[](0);
-        IBurnRedeemCore.BurnRedeemParameters memory params = IBurnRedeemCore.BurnRedeemParameters({
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](0);
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
             paymentReceiver: payable(owner),
-            storageProtocol: IBurnRedeemCore.StorageProtocol.NONE,
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
             redeemAmount: 1,
             totalSupply: 1,
             startDate: uint48(block.timestamp - 30),
@@ -71,7 +75,7 @@ contract ManifoldERC1155BurnRedeemTest is Test {
 
         // Must be admin
         vm.prank(anyone1);
-        vm.expectRevert(abi.encodePacked(IBurnRedeemCore.NotAdmin.selector, uint256(uint160(address(creator)))));
+        vm.expectRevert(abi.encodePacked(IBurnRedeemCoreV2.NotAdmin.selector, uint256(uint160(address(creator)))));
         burnRedeem.initializeBurnRedeem(address(creator), 1, params);
 
         // Succeeds because admin
@@ -80,15 +84,23 @@ contract ManifoldERC1155BurnRedeemTest is Test {
 
         // Fails because not admin
         vm.prank(anyone1);
-        vm.expectRevert(abi.encodePacked(IBurnRedeemCore.NotAdmin.selector, uint256(uint160(address(creator)))));
+        vm.expectRevert(abi.encodePacked(IBurnRedeemCoreV2.NotAdmin.selector, uint256(uint160(address(creator)))));
         burnRedeem.updateBurnRedeem(address(creator), 1, params);
+
+        // Only admin can set membership address and update fees
+        vm.startPrank(owner);
+        vm.expectRevert();
+        burnRedeem.setMembershipAddress(address(manifoldMembership));
+        vm.expectRevert();
+        burnRedeem.setBurnFees(defaultBurnFee, defaultMultiBurnFee);
+        vm.stopPrank();
     }
 
     function testInitializeSanitation() public {
-        IBurnRedeemCore.BurnGroup[] memory group = new IBurnRedeemCore.BurnGroup[](0);
-        IBurnRedeemCore.BurnRedeemParameters memory params = IBurnRedeemCore.BurnRedeemParameters({
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](0);
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
             paymentReceiver: payable(owner),
-            storageProtocol: IBurnRedeemCore.StorageProtocol.NONE,
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
             redeemAmount: 1,
             totalSupply: 10,
             startDate: uint48(block.timestamp - 30),
@@ -102,73 +114,73 @@ contract ManifoldERC1155BurnRedeemTest is Test {
 
         params.endDate = uint48(block.timestamp - 60);
         // Fails due to endDate <= startDate
-        vm.expectRevert(BurnRedeemLib.InvalidDates.selector);
+        vm.expectRevert(BurnRedeemLibV2.InvalidDates.selector);
         burnRedeem.initializeBurnRedeem(address(creator), 1, params);
 
 
         // Fails due to non-mod-0 redeemAmount
         params.endDate = uint48(block.timestamp + 1000);
         params.redeemAmount = 3;
-        vm.expectRevert(IBurnRedeemCore.InvalidRedeemAmount.selector);
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidRedeemAmount.selector);
         burnRedeem.initializeBurnRedeem(address(creator), 1, params);
 
         // Cannot update non-existant burn redeem
-        vm.expectRevert(abi.encodePacked(IBurnRedeemCore.BurnRedeemDoesNotExist.selector, uint256(1)));
+        vm.expectRevert(abi.encodePacked(IBurnRedeemCoreV2.BurnRedeemDoesNotExist.selector, uint256(1)));
         burnRedeem.updateBurnRedeem(address(creator), 1, params);
 
         // Cannot have amount == 0 on ERC1155 burn item
-        IBurnRedeemCore.BurnItem[] memory items = new IBurnRedeemCore.BurnItem[](1);
-        items[0] = IBurnRedeemCore.BurnItem({
-            validationType: IBurnRedeemCore.ValidationType.CONTRACT,
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
             contractAddress: address(burnable1155),
-            tokenSpec: IBurnRedeemCore.TokenSpec.ERC1155,
-            burnSpec: IBurnRedeemCore.BurnSpec.MANIFOLD,
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
             amount: 0,
             minTokenId: 0,
             maxTokenId: 0,
             merkleRoot: bytes32(0)
         });
         params.redeemAmount = 1;
-        group = new IBurnRedeemCore.BurnGroup[](1);
-        group[0] = IBurnRedeemCore.BurnGroup({
+        group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
             requiredCount: 1,
             items: items
         });
         params.burnSet = group;
-        vm.expectRevert(IBurnRedeemCore.InvalidInput.selector);
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidInput.selector);
         burnRedeem.initializeBurnRedeem(address(creator), 1, params);
 
         // Cannot have ValidationType == INVALID on burn item
         items[0].amount = 1;
-        items[0].validationType = IBurnRedeemCore.ValidationType.INVALID;
-        vm.expectRevert(IBurnRedeemCore.InvalidInput.selector);
+        items[0].validationType = IBurnRedeemCoreV2.ValidationType.INVALID;
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidInput.selector);
         burnRedeem.initializeBurnRedeem(address(creator), 1, params);
 
         // Cannot have TokenSpec == INVALID on burn item
-        items[0].validationType = IBurnRedeemCore.ValidationType.CONTRACT;
-        items[0].tokenSpec = IBurnRedeemCore.TokenSpec.INVALID;
-        vm.expectRevert(IBurnRedeemCore.InvalidInput.selector);
+        items[0].validationType = IBurnRedeemCoreV2.ValidationType.CONTRACT;
+        items[0].tokenSpec = IBurnRedeemCoreV2.TokenSpec.INVALID;
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidInput.selector);
         burnRedeem.initializeBurnRedeem(address(creator), 1, params);
 
         // Cannot have requiredCount == 0 on burn group
-        items[0].tokenSpec = IBurnRedeemCore.TokenSpec.ERC1155;
+        items[0].tokenSpec = IBurnRedeemCoreV2.TokenSpec.ERC1155;
         group[0].requiredCount = 0;
-        vm.expectRevert(IBurnRedeemCore.InvalidInput.selector);
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidInput.selector);
         burnRedeem.initializeBurnRedeem(address(creator), 1, params);
 
         // Cannot have requiredCount > items.length on burn group
         group[0].requiredCount = 2;
-        vm.expectRevert(IBurnRedeemCore.InvalidInput.selector);
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidInput.selector);
         burnRedeem.initializeBurnRedeem(address(creator), 1, params);
 
         vm.stopPrank();
     }
 
     function testUpdateSanitation() public {
-        IBurnRedeemCore.BurnGroup[] memory group = new IBurnRedeemCore.BurnGroup[](0);
-        IBurnRedeemCore.BurnRedeemParameters memory params = IBurnRedeemCore.BurnRedeemParameters({
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](0);
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
             paymentReceiver: payable(owner),
-            storageProtocol: IBurnRedeemCore.StorageProtocol.NONE,
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
             redeemAmount: 1,
             totalSupply: 10,
             startDate: uint48(block.timestamp - 30),
@@ -184,30 +196,30 @@ contract ManifoldERC1155BurnRedeemTest is Test {
 
         params.endDate = uint48(block.timestamp - 60);
         // Fails due to endDate <= startDate
-        vm.expectRevert(BurnRedeemLib.InvalidDates.selector);
+        vm.expectRevert(BurnRedeemLibV2.InvalidDates.selector);
         burnRedeem.updateBurnRedeem(address(creator), 1, params);
 
         // Fails due to non-mod-0 redeemAmount
         params.endDate = uint48(block.timestamp + 1000);
         params.redeemAmount = 3;
-        vm.expectRevert(IBurnRedeemCore.InvalidRedeemAmount.selector);
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidRedeemAmount.selector);
         burnRedeem.updateBurnRedeem(address(creator), 1, params);
 
-        IBurnRedeemCore.BurnToken[] memory tokens = new IBurnRedeemCore.BurnToken[](0);
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](0);
         uint256 burnFee = burnRedeem.BURN_FEE();
         burnRedeem.burnRedeem{value: burnFee*2}(address(creator), 1, 2, tokens);
 
         // Fails due to non-mod-0 redeemAmount after redemptions
         params.redeemAmount = 3;
         params.totalSupply = 9;
-        vm.expectRevert(IBurnRedeemCore.InvalidRedeemAmount.selector);
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidRedeemAmount.selector);
         burnRedeem.updateBurnRedeem(address(creator), 1, params);
 
         // totalSupply = redeemedCount if updated below redeemedCount
         params.redeemAmount = 1;
         params.totalSupply = 1;
         burnRedeem.updateBurnRedeem(address(creator), 1, params);
-        IBurnRedeemCore.BurnRedeem memory burnInstance = burnRedeem.getBurnRedeem(address(creator), 1);
+        IBurnRedeemCoreV2.BurnRedeem memory burnInstance = burnRedeem.getBurnRedeem(address(creator), 1);
         assertEq(burnInstance.totalSupply, 2);
 
         // totalSupply = 0 if updated to 0 and redeemedCount > 0
@@ -220,25 +232,25 @@ contract ManifoldERC1155BurnRedeemTest is Test {
     }
 
     function testTokenURI() public {
-        IBurnRedeemCore.BurnItem[] memory items = new IBurnRedeemCore.BurnItem[](1);
-        items[0] = IBurnRedeemCore.BurnItem({
-            validationType: IBurnRedeemCore.ValidationType.CONTRACT,
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
             contractAddress: address(burnable721),
-            tokenSpec: IBurnRedeemCore.TokenSpec.ERC721,
-            burnSpec: IBurnRedeemCore.BurnSpec.MANIFOLD,
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
             amount: 0,
             minTokenId: 0,
             maxTokenId: 0,
             merkleRoot: bytes32(0)
         });
-        IBurnRedeemCore.BurnGroup[] memory group = new IBurnRedeemCore.BurnGroup[](1);
-        group[0] = IBurnRedeemCore.BurnGroup({
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
             requiredCount: 1,
             items: items
         });
-        IBurnRedeemCore.BurnRedeemParameters memory params = IBurnRedeemCore.BurnRedeemParameters({
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
             paymentReceiver: payable(owner),
-            storageProtocol: IBurnRedeemCore.StorageProtocol.NONE,
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
             redeemAmount: 1,
             totalSupply: 10,
             startDate: uint48(block.timestamp - 30),
@@ -255,8 +267,8 @@ contract ManifoldERC1155BurnRedeemTest is Test {
         vm.startPrank(anyone1);
         burnable721.setApprovalForAll(address(burnRedeem), true);
         bytes32[] memory merkleProof;
-        IBurnRedeemCore.BurnToken[] memory tokens = new IBurnRedeemCore.BurnToken[](1);
-        tokens[0] = IBurnRedeemCore.BurnToken({
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](1);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
             groupIndex: 0,
             itemIndex: 0,
             contractAddress: address(burnable721),
@@ -273,81 +285,81 @@ contract ManifoldERC1155BurnRedeemTest is Test {
     }
 
     function testBurnAnything() public {
-        IBurnRedeemCore.BurnItem[] memory items = new IBurnRedeemCore.BurnItem[](6);
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](6);
         // tokenSpec: ERC-721, burnSpec: NONE
-        items[0] = IBurnRedeemCore.BurnItem({
-            validationType: IBurnRedeemCore.ValidationType.ANY,
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
             contractAddress: address(0),
-            tokenSpec: IBurnRedeemCore.TokenSpec.ERC721,
-            burnSpec: IBurnRedeemCore.BurnSpec.NONE,
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.NONE,
             amount: 0,
             minTokenId: 0,
             maxTokenId: 0,
             merkleRoot: bytes32(0)
         });
         // tokenSpec: ERC-721, burnSpec: MANIFOLD
-        items[1] = IBurnRedeemCore.BurnItem({
-            validationType: IBurnRedeemCore.ValidationType.ANY,
+        items[1] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
             contractAddress: address(0),
-            tokenSpec: IBurnRedeemCore.TokenSpec.ERC721,
-            burnSpec: IBurnRedeemCore.BurnSpec.MANIFOLD,
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
             amount: 0,
             minTokenId: 0,
             maxTokenId: 0,
             merkleRoot: bytes32(0)
         });
         // tokenSpec: ERC-721, burnSpec: OPENZEPPELIN
-        items[2] = IBurnRedeemCore.BurnItem({
-            validationType: IBurnRedeemCore.ValidationType.ANY,
+        items[2] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
             contractAddress: address(0),
-            tokenSpec: IBurnRedeemCore.TokenSpec.ERC721,
-            burnSpec: IBurnRedeemCore.BurnSpec.OPENZEPPELIN,
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.OPENZEPPELIN,
             amount: 0,
             minTokenId: 0,
             maxTokenId: 0,
             merkleRoot: bytes32(0)
         });
         // tokenSpec: ERC-1155, burnSpec: NONE
-        items[3] = IBurnRedeemCore.BurnItem({
-            validationType: IBurnRedeemCore.ValidationType.ANY,
+        items[3] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
             contractAddress: address(0),
-            tokenSpec: IBurnRedeemCore.TokenSpec.ERC1155,
-            burnSpec: IBurnRedeemCore.BurnSpec.NONE,
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.NONE,
             amount: 1,
             minTokenId: 0,
             maxTokenId: 0,
             merkleRoot: bytes32(0)
         });
         // tokenSpec: ERC-1155, burnSpec: MANIFOLD
-        items[4] = IBurnRedeemCore.BurnItem({
-            validationType: IBurnRedeemCore.ValidationType.ANY,
+        items[4] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
             contractAddress: address(0),
-            tokenSpec: IBurnRedeemCore.TokenSpec.ERC1155,
-            burnSpec: IBurnRedeemCore.BurnSpec.MANIFOLD,
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
             amount: 1,
             minTokenId: 0,
             maxTokenId: 0,
             merkleRoot: bytes32(0)
         });
         // tokenSpec: ERC-1155, burnSpec: OPENZEPPELIN
-        items[5] = IBurnRedeemCore.BurnItem({
-            validationType: IBurnRedeemCore.ValidationType.ANY,
+        items[5] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
             contractAddress: address(0),
-            tokenSpec: IBurnRedeemCore.TokenSpec.ERC1155,
-            burnSpec: IBurnRedeemCore.BurnSpec.OPENZEPPELIN,
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.OPENZEPPELIN,
             amount: 1,
             minTokenId: 0,
             maxTokenId: 0,
             merkleRoot: bytes32(0)
         });
-        IBurnRedeemCore.BurnGroup[] memory group = new IBurnRedeemCore.BurnGroup[](1);
-        group[0] = IBurnRedeemCore.BurnGroup({
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
             requiredCount: 1,
             items: items
         });
-        IBurnRedeemCore.BurnRedeemParameters memory params = IBurnRedeemCore.BurnRedeemParameters({
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
             paymentReceiver: payable(owner),
-            storageProtocol: IBurnRedeemCore.StorageProtocol.NONE,
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
             redeemAmount: 1,
             totalSupply: 10,
             startDate: uint48(block.timestamp - 30),
@@ -377,8 +389,8 @@ contract ManifoldERC1155BurnRedeemTest is Test {
 
         vm.deal(anyone1, 1 ether);
         bytes32[] memory merkleProof;
-        IBurnRedeemCore.BurnToken[] memory tokens = new IBurnRedeemCore.BurnToken[](1);
-        tokens[0] = IBurnRedeemCore.BurnToken({
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](1);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
             groupIndex: 0,
             itemIndex: 0,
             contractAddress: address(0),
@@ -434,25 +446,25 @@ contract ManifoldERC1155BurnRedeemTest is Test {
     }
 
     function testOnERC1155ReceivedMultiple() public {
-        IBurnRedeemCore.BurnItem[] memory items = new IBurnRedeemCore.BurnItem[](1);
-        items[0] = IBurnRedeemCore.BurnItem({
-            validationType: IBurnRedeemCore.ValidationType.CONTRACT,
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
             contractAddress: address(burnable1155),
-            tokenSpec: IBurnRedeemCore.TokenSpec.ERC1155,
-            burnSpec: IBurnRedeemCore.BurnSpec.MANIFOLD,
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
             amount: 2,
             minTokenId: 0,
             maxTokenId: 0,
             merkleRoot: bytes32(0)
         });
-        IBurnRedeemCore.BurnGroup[] memory group = new IBurnRedeemCore.BurnGroup[](1);
-        group[0] = IBurnRedeemCore.BurnGroup({
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
             requiredCount: 1,
             items: items
         });
-        IBurnRedeemCore.BurnRedeemParameters memory params = IBurnRedeemCore.BurnRedeemParameters({
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
             paymentReceiver: payable(owner),
-            storageProtocol: IBurnRedeemCore.StorageProtocol.NONE,
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
             redeemAmount: 1,
             totalSupply: 3,
             startDate: uint48(block.timestamp - 30),
@@ -488,25 +500,25 @@ contract ManifoldERC1155BurnRedeemTest is Test {
     }
 
     function testWithdraw() public {
-        IBurnRedeemCore.BurnItem[] memory items = new IBurnRedeemCore.BurnItem[](1);
-        items[0] = IBurnRedeemCore.BurnItem({
-            validationType: IBurnRedeemCore.ValidationType.CONTRACT,
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
             contractAddress: address(burnable721),
-            tokenSpec: IBurnRedeemCore.TokenSpec.ERC721,
-            burnSpec: IBurnRedeemCore.BurnSpec.MANIFOLD,
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
             amount: 0,
             minTokenId: 0,
             maxTokenId: 0,
             merkleRoot: bytes32(0)
         });
-        IBurnRedeemCore.BurnGroup[] memory group = new IBurnRedeemCore.BurnGroup[](1);
-        group[0] = IBurnRedeemCore.BurnGroup({
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
             requiredCount: 1,
             items: items
         });
-        IBurnRedeemCore.BurnRedeemParameters memory params = IBurnRedeemCore.BurnRedeemParameters({
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
             paymentReceiver: payable(owner),
-            storageProtocol: IBurnRedeemCore.StorageProtocol.NONE,
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
             redeemAmount: 1,
             totalSupply: 10,
             startDate: uint48(block.timestamp - 30),
@@ -529,13 +541,13 @@ contract ManifoldERC1155BurnRedeemTest is Test {
         uint256[] memory indexes = new uint256[](10);
         uint32[] memory burnCounts = new uint32[](10);
         bytes32[] memory merkleProof;
-        IBurnRedeemCore.BurnToken[][] memory allTokens = new IBurnRedeemCore.BurnToken[][](10);
+        IBurnRedeemCoreV2.BurnToken[][] memory allTokens = new IBurnRedeemCoreV2.BurnToken[][](10);
         for (uint256 i = 0; i < 10; i++) {
             addresses[i] = address(creator);
             indexes[i] = 1;
             burnCounts[i] = 1;
-            IBurnRedeemCore.BurnToken[] memory tokens = new IBurnRedeemCore.BurnToken[](1);
-            IBurnRedeemCore.BurnToken memory token = IBurnRedeemCore.BurnToken({
+            IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](1);
+            IBurnRedeemCoreV2.BurnToken memory token = IBurnRedeemCoreV2.BurnToken({
                 groupIndex: 0,
                 itemIndex: 0,
                 contractAddress: address(burnable721),
@@ -552,7 +564,7 @@ contract ManifoldERC1155BurnRedeemTest is Test {
         vm.prank(anyone2);
         vm.expectRevert("AdminControl: Must be owner or admin");
         burnRedeem.withdraw(payable(anyone2), burnFee*10);
-        
+
         vm.prank(burnRedeemOwner);
         vm.expectRevert();
         burnRedeem.withdraw(payable(owner), burnFee*11);
@@ -563,25 +575,25 @@ contract ManifoldERC1155BurnRedeemTest is Test {
     }
 
     function testAirdrop() public {
-        IBurnRedeemCore.BurnItem[] memory items = new IBurnRedeemCore.BurnItem[](1);
-        items[0] = IBurnRedeemCore.BurnItem({
-            validationType: IBurnRedeemCore.ValidationType.CONTRACT,
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
             contractAddress: address(burnable721),
-            tokenSpec: IBurnRedeemCore.TokenSpec.ERC721,
-            burnSpec: IBurnRedeemCore.BurnSpec.MANIFOLD,
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
             amount: 0,
             minTokenId: 0,
             maxTokenId: 0,
             merkleRoot: bytes32(0)
         });
-        IBurnRedeemCore.BurnGroup[] memory group = new IBurnRedeemCore.BurnGroup[](1);
-        group[0] = IBurnRedeemCore.BurnGroup({
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
             requiredCount: 1,
             items: items
         });
-        IBurnRedeemCore.BurnRedeemParameters memory params = IBurnRedeemCore.BurnRedeemParameters({
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
             paymentReceiver: payable(owner),
-            storageProtocol: IBurnRedeemCore.StorageProtocol.NONE,
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
             redeemAmount: 2,
             totalSupply: 10,
             startDate: uint48(block.timestamp - 30),
@@ -602,7 +614,7 @@ contract ManifoldERC1155BurnRedeemTest is Test {
         amounts[1] = 1;
 
         vm.prank(anyone1);
-        vm.expectRevert(abi.encodePacked(IBurnRedeemCore.NotAdmin.selector, uint256(uint160(address(creator)))));
+        vm.expectRevert(abi.encodePacked(IBurnRedeemCoreV2.NotAdmin.selector, uint256(uint160(address(creator)))));
         burnRedeem.airdrop(address(creator), 1, recipients, amounts);
 
         vm.prank(owner);
@@ -613,7 +625,7 @@ contract ManifoldERC1155BurnRedeemTest is Test {
         assertEq(2, creator.balanceOf(anyone2, 1));
 
         // redeemedCount updated
-        IBurnRedeemCore.BurnRedeem memory burnInstance = burnRedeem.getBurnRedeem(address(creator), 1);
+        IBurnRedeemCoreV2.BurnRedeem memory burnInstance = burnRedeem.getBurnRedeem(address(creator), 1);
         assertEq(burnInstance.redeemedCount, 4);
         assertEq(burnInstance.totalSupply, 10);
 
@@ -638,28 +650,28 @@ contract ManifoldERC1155BurnRedeemTest is Test {
         amounts = new uint32[](1);
         amounts[0] = 2147483647;
         vm.prank(owner);
-        vm.expectRevert(IBurnRedeemCore.InvalidRedeemAmount.selector);
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidRedeemAmount.selector);
         burnRedeem.airdrop(address(creator), 1, recipients, amounts);
     }
 
     function testBurnRedeemWithMixedItems() public {
         // Set up the burn items
-        IBurnRedeemCore.BurnItem[] memory items = new IBurnRedeemCore.BurnItem[](2);
-        items[0] = IBurnRedeemCore.BurnItem({
-            validationType: IBurnRedeemCore.ValidationType.CONTRACT,
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](2);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
             contractAddress: address(burnable1155),
-            tokenSpec: IBurnRedeemCore.TokenSpec.ERC1155,
-            burnSpec: IBurnRedeemCore.BurnSpec.MANIFOLD,
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
             amount: 3,
             minTokenId: 0,
             maxTokenId: 0,
             merkleRoot: bytes32(0)
         });
-        items[1] = IBurnRedeemCore.BurnItem({
-            validationType: IBurnRedeemCore.ValidationType.CONTRACT,
+        items[1] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
             contractAddress: address(burnable721),
-            tokenSpec: IBurnRedeemCore.TokenSpec.ERC721,
-            burnSpec: IBurnRedeemCore.BurnSpec.NONE,
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.NONE,
             amount: 0,
             minTokenId: 0,
             maxTokenId: 0,
@@ -667,16 +679,16 @@ contract ManifoldERC1155BurnRedeemTest is Test {
         });
 
         // Set up the burn group
-        IBurnRedeemCore.BurnGroup[] memory group = new IBurnRedeemCore.BurnGroup[](1);
-        group[0] = IBurnRedeemCore.BurnGroup({
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
             requiredCount: 1,
             items: items
         });
 
         // Set up the burn redeem parameters
-        IBurnRedeemCore.BurnRedeemParameters memory params = IBurnRedeemCore.BurnRedeemParameters({
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
             paymentReceiver: payable(owner),
-            storageProtocol: IBurnRedeemCore.StorageProtocol.NONE,
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
             redeemAmount: 1,
             totalSupply: 10,
             startDate: uint48(block.timestamp - 30),
@@ -703,7 +715,7 @@ contract ManifoldERC1155BurnRedeemTest is Test {
 
         // check they own 3x 1155 tokens
         assertEq(burnable1155.balanceOf(anyone1, tokenIds[0]), 3);
-        console.log("tokenIds[0]", tokenIds[0]);
+     
         vm.stopPrank();
 
 
@@ -715,8 +727,8 @@ contract ManifoldERC1155BurnRedeemTest is Test {
 
         // Perform the burn redeem
         // @note: we only use one group here because the item it maps to has the 3x multiplier
-        IBurnRedeemCore.BurnToken[] memory tokens = new IBurnRedeemCore.BurnToken[](1);
-        tokens[0] = IBurnRedeemCore.BurnToken({
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](1);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
             groupIndex: 0,
             itemIndex: 0,
             contractAddress: address(burnable1155),
@@ -729,6 +741,264 @@ contract ManifoldERC1155BurnRedeemTest is Test {
 
         // Verify the burns
         assertEq(burnable1155.balanceOf(anyone1, tokenIds[0]), 0);
+        vm.stopPrank();
+    }
+
+    function testSetBurnFees() public {
+        uint256 newBurnFee = defaultBurnFee + 1000000;
+        uint256 newMultiBurnFee = defaultMultiBurnFee + 1000000;
+
+         // Owner can set fees
+        vm.prank(burnRedeemOwner);
+        burnRedeem.setBurnFees(newBurnFee, newMultiBurnFee);
+
+        // Verify fees were set correctly
+        assertEq(burnRedeem.BURN_FEE(), newBurnFee);
+        assertEq(burnRedeem.MULTI_BURN_FEE(), newMultiBurnFee);
+
+        // test burns with new fees
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](6);
+         // tokenSpec: ERC-721, burnSpec: NONE
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
+            contractAddress: address(0),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.NONE,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        // tokenSpec: ERC-721, burnSpec: MANIFOLD
+        items[1] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
+            contractAddress: address(0),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        // tokenSpec: ERC-721, burnSpec: OPENZEPPELIN
+        items[2] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
+            contractAddress: address(0),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.OPENZEPPELIN,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        // tokenSpec: ERC-1155, burnSpec: NONE
+        items[3] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
+            contractAddress: address(0),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.NONE,
+            amount: 1,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        // tokenSpec: ERC-1155, burnSpec: MANIFOLD
+        items[4] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
+            contractAddress: address(0),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 1,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        // tokenSpec: ERC-1155, burnSpec: OPENZEPPELIN
+        items[5] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
+            contractAddress: address(0),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.OPENZEPPELIN,
+            amount: 1,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params);
+
+        // Mint tokens to anyone1
+        oz721.mint(anyone1, 1);
+        burnable721.mintBase(anyone1);
+        oz721Burnable.mint(anyone1, 1);
+        oz1155.mint(anyone1, 1, 1);
+        address[] memory recipients = new address[](1);
+        recipients[0] = anyone1;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 1;
+        string[] memory uris = new string[](1);
+        uris[0] = "";
+        burnable1155.mintBaseNew(recipients, amounts, uris);
+        oz1155Burnable.mint(anyone1, 1, 1);
+
+        vm.stopPrank();
+
+        vm.deal(anyone1, 1 ether);
+        bytes32[] memory merkleProof;
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](1);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(0),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        uint256 burnFee = newBurnFee;
+
+        vm.startPrank(anyone1);
+        oz721.setApprovalForAll(address(burnRedeem), true);
+        tokens[0].contractAddress = address(oz721);
+        tokens[0].itemIndex = 0;
+        vm.expectRevert();
+        burnRedeem.burnRedeem{value: defaultBurnFee}(address(creator), 1, 1, tokens);
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        assertEq(0, oz721.balanceOf(anyone1));
+        assertEq(1, oz721.balanceOf(address(0x000000000000000000000000000000000000dEaD)));
+
+        burnable721.setApprovalForAll(address(burnRedeem), true);
+        tokens[0].contractAddress = address(burnable721);
+        tokens[0].itemIndex = 1;
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        vm.expectRevert("ERC721: invalid token ID");
+        burnable721.ownerOf(1);
+
+        oz721Burnable.setApprovalForAll(address(burnRedeem), true);
+        tokens[0].contractAddress = address(oz721Burnable);
+        tokens[0].itemIndex = 2;
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        vm.expectRevert("ERC721: invalid token ID");
+        oz721Burnable.ownerOf(1);
+
+        oz1155.setApprovalForAll(address(burnRedeem), true);
+        tokens[0].contractAddress = address(oz1155);
+        tokens[0].itemIndex = 3;
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        assertEq(0, oz1155.balanceOf(anyone1, 1));
+        assertEq(1, oz1155.balanceOf(address(0x000000000000000000000000000000000000dEaD), 1));
+
+        burnable1155.setApprovalForAll(address(burnRedeem), true);
+        tokens[0].contractAddress = address(burnable1155);
+        tokens[0].itemIndex = 4;
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        assertEq(0, burnable1155.balanceOf(anyone1, 1));
+        assertEq(0, burnable1155.totalSupply(1));
+
+        oz1155Burnable.setApprovalForAll(address(burnRedeem), true);
+        tokens[0].contractAddress = address(oz1155Burnable);
+        tokens[0].itemIndex = 5;
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        assertEq(0, oz1155Burnable.balanceOf(anyone1, 1));
+        assertEq(0, oz1155Burnable.balanceOf(address(0x000000000000000000000000000000000000dEaD), 1));
+
+        vm.stopPrank();
+    }
+
+    function testSetActive() public {
+       // stop new burns from being initialized
+        vm.startPrank(burnRedeemOwner);
+        burnRedeem.setActive(false);
+        vm.stopPrank();
+
+        vm.startPrank(owner);
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(burnable1155),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 1,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 2,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.expectRevert(IBurnRedeemCoreV2.Inactive.selector);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params);
+        vm.stopPrank();
+
+        // resume new burns
+        vm.startPrank(burnRedeemOwner);
+        burnRedeem.setActive(true);
+        vm.stopPrank();
+
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params);
+        vm.stopPrank();
+
+        // can still burn even if claim creations are paused
+        vm.startPrank(burnRedeemOwner);
+        burnRedeem.setActive(false);
+        vm.stopPrank();
+
+        vm.startPrank(owner);
+        address[] memory recipients = new address[](1);
+        recipients[0] = anyone1;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 3;
+        string[] memory uris = new string[](1);
+        uris[0] = "";
+
+        uint256[] memory tokenIds = burnable1155.mintBaseNew(recipients, amounts, uris);
+
+        // check they own 3x 1155 tokens
+        assertEq(burnable1155.balanceOf(anyone1, tokenIds[0]), 3);
+
+        vm.stopPrank();
+        
+        vm.startPrank(anyone1);
+
+        vm.deal(anyone1, 1 ether);
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](1);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(burnable1155),
+            id: tokenIds[0],
+            merkleProof: new bytes32[](0)
+        });
+        burnable1155.setApprovalForAll(address(burnRedeem), true);
+        burnRedeem.burnRedeem{value: defaultBurnFee}(address(creator), 1, 1, tokens);
         vm.stopPrank();
     }
 

--- a/packages/manifold/test/burnredeemUpdatableFee/ERC721BurnRedeemV2.t.sol
+++ b/packages/manifold/test/burnredeemUpdatableFee/ERC721BurnRedeemV2.t.sol
@@ -1,0 +1,2676 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "../../contracts/burnredeemUpdatableFee/ERC721BurnRedeemV2.sol";
+import "@manifoldxyz/creator-core-solidity/contracts/ERC721Creator.sol";
+import "@manifoldxyz/creator-core-solidity/contracts/ERC1155Creator.sol";
+
+import "../mocks/Mock.sol";
+
+contract ManifoldERC721BurnRedeemV2Test is Test {
+    ERC721BurnRedeemV2 public burnRedeem;
+    ERC721Creator public creator;
+    MockManifoldMembership public manifoldMembership;
+    ERC721Creator public burnable721;
+    ERC721Creator public burnable721_2;
+    ERC1155Creator public burnable1155;
+    ERC1155Creator public burnable1155_2;
+    MockERC721 public oz721;
+    MockERC1155 public oz1155;
+    MockERC721Burnable public oz721Burnable;
+    MockERC1155Burnable public oz1155Burnable;
+    MockERC1155Fallback public fallback1155;
+    MockERC1155FallbackBurnable public fallback1155Burnable;
+
+    uint256 public defaultBurnFee = 690000000000000;
+    uint256 public defaultMultiBurnFee = 990000000000000;
+
+    address public owner = 0x6140F00e4Ff3936702E68744f2b5978885464cbB;
+    address public burnRedeemOwner = 0xc78Dc443c126af6E4f6Ed540c1e740C1b5be09cd;
+    address public anyone1 = 0x80AAC46bbd3C2FcE33681541a52CacBEd14bF425;
+    address public anyone2 = 0x5174cD462b60c536eb51D4ceC1D561D3Ea31004F;
+
+    address public zeroAddress = address(0);
+    address public deadAddress = 0x000000000000000000000000000000000000dEaD;
+
+    function setUp() public {
+        vm.startPrank(owner);
+        creator = new ERC721Creator("Test", "TEST");
+        burnRedeem = new ERC721BurnRedeemV2(burnRedeemOwner);
+        manifoldMembership = new MockManifoldMembership();
+        burnable721 = new ERC721Creator("Test", "TEST");
+        burnable721_2 = new ERC721Creator("Test", "TEST");
+        burnable1155 = new ERC1155Creator("Test", "TEST");
+        burnable1155_2 = new ERC1155Creator("Test", "TEST");
+        oz721 = new MockERC721("Test", "TEST");
+        oz1155 = new MockERC1155("test.com");
+        oz721Burnable = new MockERC721Burnable("Test", "TEST");
+        oz1155Burnable = new MockERC1155Burnable("test.com");
+        fallback1155 = new MockERC1155Fallback("test.com");
+        fallback1155Burnable = new MockERC1155FallbackBurnable("test.com");
+        creator.registerExtension(address(burnRedeem), "");
+        vm.stopPrank();
+
+        vm.startPrank(burnRedeemOwner);
+        burnRedeem.setMembershipAddress(address(manifoldMembership));
+        burnRedeem.setBurnFees(defaultBurnFee, defaultMultiBurnFee);
+        vm.stopPrank();
+        vm.warp(100000);
+    }
+
+    function testAccess() public {
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](0);
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 1,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "",
+            burnSet: group
+        });
+
+        // Must be admin
+        vm.prank(anyone1);
+        vm.expectRevert(abi.encodePacked(IBurnRedeemCoreV2.NotAdmin.selector, uint256(uint160(address(creator)))));
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, true);
+
+        // Succeeds because admin
+        vm.prank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, true);
+
+        // Fails because not admin
+        vm.prank(anyone1);
+        vm.expectRevert(abi.encodePacked(IBurnRedeemCoreV2.NotAdmin.selector, uint256(uint160(address(creator)))));
+        burnRedeem.updateBurnRedeem(address(creator), 1, params, true);
+
+        // Only admin can set membership address and update fees
+        vm.startPrank(owner);
+        vm.expectRevert();
+        burnRedeem.setMembershipAddress(address(manifoldMembership));
+        vm.expectRevert();
+        burnRedeem.setBurnFees(defaultBurnFee, defaultMultiBurnFee);
+        vm.stopPrank();
+    }
+
+    function testInitializeSanitation() public {
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](0);
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "",
+            burnSet: group
+        });
+
+        vm.startPrank(owner);
+
+        params.endDate = uint48(block.timestamp - 60);
+        // Fails due to endDate <= startDate
+        vm.expectRevert(BurnRedeemLibV2.InvalidDates.selector);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, true);
+
+
+        // Fails due to non-mod-0 redeemAmount
+        params.endDate = uint48(block.timestamp + 1000);
+        params.redeemAmount = 3;
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidRedeemAmount.selector);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, true);
+
+        // Cannot update non-existant burn redeem
+        vm.expectRevert(abi.encodePacked(IBurnRedeemCoreV2.BurnRedeemDoesNotExist.selector, uint256(1)));
+        burnRedeem.updateBurnRedeem(address(creator), 1, params, true);
+
+        // Cannot have amount == 0 on ERC1155 burn item
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(burnable1155),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        params.redeemAmount = 1;
+        group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        params.burnSet = group;
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidInput.selector);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, true);
+
+        // Cannot have ValidationType == INVALID on burn item
+        items[0].amount = 1;
+        items[0].validationType = IBurnRedeemCoreV2.ValidationType.INVALID;
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidInput.selector);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, true);
+
+        // Cannot have TokenSpec == INVALID on burn item
+        items[0].validationType = IBurnRedeemCoreV2.ValidationType.CONTRACT;
+        items[0].tokenSpec = IBurnRedeemCoreV2.TokenSpec.INVALID;
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidInput.selector);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, true);
+
+        // Cannot have requiredCount == 0 on burn group
+        items[0].tokenSpec = IBurnRedeemCoreV2.TokenSpec.ERC1155;
+        group[0].requiredCount = 0;
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidInput.selector);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, true);
+
+        // Cannot have requiredCount > items.length on burn group
+        group[0].requiredCount = 2;
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidInput.selector);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, true);
+
+        vm.stopPrank();
+    }
+
+    function testUpdateSanitation() public {
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](0);
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "",
+            burnSet: group
+        });
+
+        vm.deal(owner, 1 ether);
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, true);
+
+        params.endDate = uint48(block.timestamp - 60);
+        // Fails due to endDate <= startDate
+        vm.expectRevert(BurnRedeemLibV2.InvalidDates.selector);
+        burnRedeem.updateBurnRedeem(address(creator), 1, params, true);
+
+        // Fails due to non-mod-0 redeemAmount
+        params.endDate = uint48(block.timestamp + 1000);
+        params.redeemAmount = 3;
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidRedeemAmount.selector);
+        burnRedeem.updateBurnRedeem(address(creator), 1, params, true);
+
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](0);
+        uint256 burnFee = burnRedeem.BURN_FEE();
+        burnRedeem.burnRedeem{value: burnFee*2}(address(creator), 1, 2, tokens);
+
+        // Fails due to non-mod-0 redeemAmount after redemptions
+        params.redeemAmount = 3;
+        params.totalSupply = 9;
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidRedeemAmount.selector);
+        burnRedeem.updateBurnRedeem(address(creator), 1, params, true);
+
+        // totalSupply = redeemedCount if updated below redeemedCount
+        params.redeemAmount = 1;
+        params.totalSupply = 1;
+        burnRedeem.updateBurnRedeem(address(creator), 1, params, true);
+        IBurnRedeemCoreV2.BurnRedeem memory burnInstance = burnRedeem.getBurnRedeem(address(creator), 1);
+        assertEq(burnInstance.totalSupply, 2);
+
+        // totalSupply = 0 if updated to 0 and redeemedCount > 0
+        params.totalSupply = 0;
+        burnRedeem.updateBurnRedeem(address(creator), 1, params, true);
+        burnInstance = burnRedeem.getBurnRedeem(address(creator), 1);
+        assertEq(burnInstance.totalSupply, 0);
+
+        vm.stopPrank();
+    }
+
+    function testTokenURI() public {
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(burnable721),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, true);
+        burnable721.mintBase(anyone1);
+        vm.stopPrank();
+        vm.deal(anyone1, 1 ether);
+        vm.startPrank(anyone1);
+        burnable721.setApprovalForAll(address(burnRedeem), true);
+        bytes32[] memory merkleProof;
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](1);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(burnable721),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        uint256 burnFee = burnRedeem.BURN_FEE();
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+
+        string memory uri = creator.tokenURI(1);
+        assertEq(uri, "XXX");
+
+        vm.stopPrank();
+
+        vm.prank(owner);
+        burnRedeem.updateBurnRedeem(address(creator), 1, params, false);
+        uri = creator.tokenURI(1);
+        assertEq(uri, "XXX/1");
+    }
+
+    function testTokenURIWithMintInBetween() public {
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(burnable721),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, false);
+        burnable721.mintBase(anyone1);
+        burnable721.mintBase(anyone1);
+        vm.stopPrank();
+
+        vm.deal(anyone1, 1 ether);
+
+        vm.prank(anyone1);
+        burnable721.setApprovalForAll(address(burnRedeem), true);
+
+        bytes32[] memory merkleProof;
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](1);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(burnable721),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        uint256 burnFee = burnRedeem.BURN_FEE();
+
+        // Redeem first token
+        vm.prank(anyone1);
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        string memory uri = creator.tokenURI(1);
+        assertEq(uri, "XXX/1");
+
+        vm.prank(owner);
+        creator.mintBase(anyone1);
+
+        // Redeem another token
+        tokens[0].id = 2;
+        vm.prank(anyone1);
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        uri = creator.tokenURI(3);
+        assertEq(uri, "XXX/2");
+    }
+
+    function testBurnAnything() public {
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](6);
+        // tokenSpec: ERC-721, burnSpec: NONE
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
+            contractAddress: address(0),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.NONE,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        // tokenSpec: ERC-721, burnSpec: MANIFOLD
+        items[1] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
+            contractAddress: address(0),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        // tokenSpec: ERC-721, burnSpec: OPENZEPPELIN
+        items[2] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
+            contractAddress: address(0),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.OPENZEPPELIN,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        // tokenSpec: ERC-1155, burnSpec: NONE
+        items[3] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
+            contractAddress: address(0),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.NONE,
+            amount: 1,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        // tokenSpec: ERC-1155, burnSpec: MANIFOLD
+        items[4] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
+            contractAddress: address(0),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 1,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        // tokenSpec: ERC-1155, burnSpec: OPENZEPPELIN
+        items[5] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
+            contractAddress: address(0),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.OPENZEPPELIN,
+            amount: 1,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, false);
+
+        // Mint tokens to anyone1
+        oz721.mint(anyone1, 1);
+        burnable721.mintBase(anyone1);
+        oz721Burnable.mint(anyone1, 1);
+        oz1155.mint(anyone1, 1, 1);
+        address[] memory recipients = new address[](1);
+        recipients[0] = anyone1;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 1;
+        string[] memory uris = new string[](1);
+        uris[0] = "";
+        burnable1155.mintBaseNew(recipients, amounts, uris);
+        oz1155Burnable.mint(anyone1, 1, 1);
+
+        vm.stopPrank();
+
+        vm.deal(anyone1, 1 ether);
+        bytes32[] memory merkleProof;
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](1);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(0),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        uint256 burnFee = burnRedeem.BURN_FEE();
+
+        vm.startPrank(anyone1);
+        oz721.setApprovalForAll(address(burnRedeem), true);
+        tokens[0].contractAddress = address(oz721);
+        tokens[0].itemIndex = 0;
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        assertEq(0, oz721.balanceOf(anyone1));
+        assertEq(1, oz721.balanceOf(address(0x000000000000000000000000000000000000dEaD)));
+
+        burnable721.setApprovalForAll(address(burnRedeem), true);
+        tokens[0].contractAddress = address(burnable721);
+        tokens[0].itemIndex = 1;
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        vm.expectRevert("ERC721: invalid token ID");
+        burnable721.ownerOf(1);
+
+        oz721Burnable.setApprovalForAll(address(burnRedeem), true);
+        tokens[0].contractAddress = address(oz721Burnable);
+        tokens[0].itemIndex = 2;
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        vm.expectRevert("ERC721: invalid token ID");
+        oz721Burnable.ownerOf(1);
+
+        oz1155.setApprovalForAll(address(burnRedeem), true);
+        tokens[0].contractAddress = address(oz1155);
+        tokens[0].itemIndex = 3;
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        assertEq(0, oz1155.balanceOf(anyone1, 1));
+        assertEq(1, oz1155.balanceOf(address(0x000000000000000000000000000000000000dEaD), 1));
+
+        burnable1155.setApprovalForAll(address(burnRedeem), true);
+        tokens[0].contractAddress = address(burnable1155);
+        tokens[0].itemIndex = 4;
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        assertEq(0, burnable1155.balanceOf(anyone1, 1));
+        assertEq(0, burnable1155.totalSupply(1));
+
+        oz1155Burnable.setApprovalForAll(address(burnRedeem), true);
+        tokens[0].contractAddress = address(oz1155Burnable);
+        tokens[0].itemIndex = 5;
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        assertEq(0, oz1155Burnable.balanceOf(anyone1, 1));
+        assertEq(0, oz1155Burnable.balanceOf(address(0x000000000000000000000000000000000000dEaD), 1));
+
+        vm.stopPrank();
+    }
+
+    function testRedeemWithCustomDataEmitted() public {
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(oz721),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.NONE,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, false);
+        oz721.mint(anyone1, 1);
+        oz721.mint(anyone1, 2);
+        oz721.mint(anyone1, 3);
+        vm.stopPrank();
+
+        vm.deal(anyone1, 1 ether);
+
+        vm.prank(anyone1);
+        oz721.setApprovalForAll(address(burnRedeem), true);
+
+        bytes memory message = bytes("test");
+        bytes32[] memory merkleProof;
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](1);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(oz721),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        uint256 burnFee = burnRedeem.BURN_FEE();
+
+        // Redeem first token
+        vm.prank(anyone1);
+        vm.expectEmit();
+        emit BurnRedeemLibV2.BurnRedeemMint(address(creator), 1, 1, 1, message);
+        burnRedeem.burnRedeemWithData{value: burnFee}(address(creator), 1, 1, tokens, message);
+        assertEq(2, oz721.balanceOf(anyone1));
+        assertEq(1, creator.balanceOf(anyone1));
+    }
+
+    function testContractsWithFallbackCannotBypass() public {
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(fallback1155),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.NONE,
+            amount: 1,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, false);
+        fallback1155.mint(anyone1, 1, 1);
+        vm.stopPrank();
+
+        vm.deal(anyone1, 1 ether);
+
+        vm.prank(anyone1);
+        fallback1155.setApprovalForAll(address(burnRedeem), true);
+        bytes32[] memory merkleProof;
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](1);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(fallback1155),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        uint256 burnFee = burnRedeem.BURN_FEE();
+
+        vm.prank(anyone1);
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        assertEq(1, fallback1155.balanceOf(address(0x000000000000000000000000000000000000dEaD), 1));
+    }
+
+    function testBurn721() public {
+        /**
+         *   const merkleElements = [];
+         *   merkleElements.push(ethers.utils.solidityPack(["uint256"], [3]));
+         *   merkleElements.push(ethers.utils.solidityPack(["uint256"], [10]));
+         *   merkleElements.push(ethers.utils.solidityPack(["uint256"], [15]));
+         *   merkleElements.push(ethers.utils.solidityPack(["uint256"], [20]));
+         *   merkleTreeWithValues = new MerkleTree(merkleElements, keccak256, { hashLeaves: true, sortPairs: true });
+         *   merkleRoot = merkleTreeWithValues.getHexRoot()
+         */
+        IBurnRedeemCoreV2.BurnItem[] memory items1 = new IBurnRedeemCoreV2.BurnItem[](1);
+        items1[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(burnable721),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnItem[] memory items2 = new IBurnRedeemCoreV2.BurnItem[](2);
+        items2[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.RANGE,
+            contractAddress: address(burnable721_2),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 0,
+            minTokenId: 1,
+            maxTokenId: 2,
+            merkleRoot: bytes32(0)
+        });
+        items2[1] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.MERKLE_TREE,
+            contractAddress: address(burnable721_2),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0x9c1cfb2dc26ce204a49fc7b1a9b4e3a57e9344e39ee46ac2d6208d1c058e4bf0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](2);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items1
+        });
+        group[1] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items2
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, false);
+        for (uint256 i = 0; i < 4; i++) {
+            burnable721.mintBase(anyone1);
+            burnable721_2.mintBase(anyone1);
+        }
+        vm.stopPrank();
+
+        vm.deal(anyone1, 1 ether);
+
+        vm.startPrank(anyone1);
+        burnable721.setApprovalForAll(address(burnRedeem), true);
+        burnable721_2.setApprovalForAll(address(burnRedeem), true);
+
+        bytes32[] memory merkleProof;
+        bytes32[] memory merkleProofToken3 = new bytes32[](2);
+        merkleProofToken3[0] = bytes32(0xc65a7bb8d6351c1cf70c95a316cc6a92839c986682d98bc35f958f4883f9d2a8);
+        merkleProofToken3[1] = bytes32(0xe465c7176713655952e4cd0925e3c01b046d9399e14c8fcbea1a9839720e1928);
+
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](1);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(burnable721),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        uint256 burnFee = burnRedeem.MULTI_BURN_FEE();
+
+        // Reverts due to unmet requirements
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidBurnAmount.selector);
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+
+        // Reverts due to too many tokens
+        tokens = new IBurnRedeemCoreV2.BurnToken[](3);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(burnable721),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        tokens[1] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 1,
+            itemIndex: 0,
+            contractAddress: address(burnable721_2),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        tokens[2] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 1,
+            itemIndex: 1,
+            contractAddress: address(burnable721_2),
+            id: 3,
+            merkleProof: merkleProofToken3
+        });
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidBurnAmount.selector);
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+
+        // Reverts when token ID out of range
+        tokens = new IBurnRedeemCoreV2.BurnToken[](2);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(burnable721),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        tokens[1] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 1,
+            itemIndex: 0,
+            contractAddress: address(burnable721_2),
+            id: 3,
+            merkleProof: merkleProof
+        });
+        vm.expectRevert(abi.encodePacked(IBurnRedeemCoreV2.InvalidToken.selector, uint256(3)));
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+
+        // Reverts with invalid merkle proof
+        tokens = new IBurnRedeemCoreV2.BurnToken[](2);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(burnable721),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        tokens[1] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 1,
+            itemIndex: 1,
+            contractAddress: address(burnable721_2),
+            id: 2,
+            merkleProof: merkleProof
+        });
+        vm.expectRevert(BurnRedeemLibV2.InvalidMerkleProof.selector);
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+
+        // Reverts due to no fee
+        tokens = new IBurnRedeemCoreV2.BurnToken[](2);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(burnable721),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        tokens[1] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 1,
+            itemIndex: 0,
+            contractAddress: address(burnable721_2),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidPaymentAmount.selector);
+        burnRedeem.burnRedeem(address(creator), 1, 1, tokens);
+
+        // Reverts when msg.sender is not token owner, but tokens are approved
+        vm.stopPrank();
+        vm.deal(anyone2, 1 ether);
+        vm.prank(anyone2);
+        vm.expectRevert(IBurnRedeemCoreV2.TransferFailure.selector);
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+
+        // Reverts with burnCount > 1
+        vm.startPrank(anyone1);
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidBurnAmount.selector);
+        burnRedeem.burnRedeem{value: burnFee*2}(address(creator), 1, 2, tokens);
+
+        // Passes with met requirements - range
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+
+        (uint256 burnInstanceId, IBurnRedeemCoreV2.BurnRedeem memory burnInstance) = burnRedeem.getBurnRedeemForToken(address(creator), 1);
+        assertEq(burnInstanceId, 1);
+        assertEq(burnInstance.contractVersion, 3);
+
+        // Passes with met requirements - merkle tree
+        tokens[0].id = 2;
+        tokens[1].itemIndex = 1;
+        tokens[1].id = 3;
+        tokens[1].merkleProof = merkleProofToken3;
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+
+        // Ensure tokens are burned/minted
+        assertEq(2, burnable721.balanceOf(anyone1));
+        assertEq(2, burnable721_2.balanceOf(anyone1));
+        assertEq(2, creator.balanceOf(anyone1));
+        vm.stopPrank();
+    }
+
+    function testBurn721BurnSpecNone() public {
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(oz721),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.NONE,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, false);
+        for (uint256 i = 0; i < 4; i++) {
+            oz721.mint(anyone1, i);
+        }
+        vm.stopPrank();
+
+        vm.deal(anyone1, 1 ether);
+
+        vm.startPrank(anyone1);
+        oz721.setApprovalForAll(address(burnRedeem), true);
+
+        // Reverts due to unmet requirements
+        bytes32[] memory merkleProof;
+
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](1);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(oz721),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        uint256 burnFee = burnRedeem.BURN_FEE();
+
+        // Passes with met requirements - range
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        // Ensure tokens are burned/minted
+        assertEq(3, oz721.balanceOf(anyone1));
+        assertEq(1, oz721.balanceOf(address(0xdead)));
+        assertEq(1, creator.balanceOf(anyone1));
+        vm.stopPrank();
+    }
+
+    function testBurn721BurnSpecOpenzeppelin() public {
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(oz721Burnable),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.OPENZEPPELIN,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, false);
+        for (uint256 i = 0; i < 4; i++) {
+            oz721Burnable.mint(anyone1, i);
+        }
+        vm.stopPrank();
+
+        vm.deal(anyone1, 1 ether);
+
+        vm.startPrank(anyone1);
+        oz721Burnable.setApprovalForAll(address(burnRedeem), true);
+
+        // Reverts due to unmet requirements
+        bytes32[] memory merkleProof;
+
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](1);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(oz721Burnable),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        uint256 burnFee = burnRedeem.BURN_FEE();
+
+        // Passes with met requirement
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        // Ensure tokens are burned/minted
+        assertEq(3, oz721Burnable.balanceOf(anyone1));
+        assertEq(0, oz721Burnable.balanceOf(address(0xdead)));
+        assertEq(1, creator.balanceOf(anyone1));
+        vm.stopPrank();
+    }
+
+    function testBurn1155() public {
+        /**
+         *   const merkleElements = [];
+         *   merkleElements.push(ethers.utils.solidityPack(["uint256"], [2]));
+         *   merkleElements.push(ethers.utils.solidityPack(["uint256"], [10]));
+         *   merkleElements.push(ethers.utils.solidityPack(["uint256"], [15]));
+         *   merkleElements.push(ethers.utils.solidityPack(["uint256"], [20]));
+         *   merkleTreeWithValues = new MerkleTree(merkleElements, keccak256, { hashLeaves: true, sortPairs: true });
+         *   merkleRoot = merkleTreeWithValues.getHexRoot()
+         */
+
+        IBurnRedeemCoreV2.BurnItem[] memory items1 = new IBurnRedeemCoreV2.BurnItem[](1);
+        items1[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(burnable1155_2),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 2,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnItem[] memory items2 = new IBurnRedeemCoreV2.BurnItem[](1);
+        items2[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.RANGE,
+            contractAddress: address(burnable1155),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 1,
+            minTokenId: 1,
+            maxTokenId: 2,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnItem[] memory items3 = new IBurnRedeemCoreV2.BurnItem[](2);
+        items3[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.MERKLE_TREE,
+            contractAddress: address(burnable1155),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 1,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0xa0e5e9d42a6adc6538b879161a5503e44aacae809116f3c8f0507a06728a04fc)
+        });
+        items3[1] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(burnable721),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](3);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items1
+        });
+        group[1] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items2
+        });
+        group[2] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items3
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, false);
+        address[] memory recipients = new address[](1);
+        recipients[0] = anyone1;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 10;
+        string[] memory uris = new string[](1);
+        uris[0] = "";
+        burnable1155.mintBaseNew(recipients, amounts, uris);
+        burnable1155.mintBaseNew(recipients, amounts, uris);
+        burnable1155_2.mintBaseNew(recipients, amounts, uris);
+        burnable721.mintBase(anyone1);
+        vm.stopPrank();
+
+        vm.deal(anyone1, 1 ether);
+
+        vm.startPrank(anyone1);
+        burnable1155.setApprovalForAll(address(burnRedeem), true);
+        burnable1155_2.setApprovalForAll(address(burnRedeem), true);
+        burnable721.setApprovalForAll(address(burnRedeem), true);
+
+        // Reverts due to unmet requirements
+        bytes32[] memory merkleProof;
+        bytes32[] memory merkleProofToken2 = new bytes32[](2);
+        merkleProofToken2[0] = bytes32(0xc65a7bb8d6351c1cf70c95a316cc6a92839c986682d98bc35f958f4883f9d2a8);
+        merkleProofToken2[1] = bytes32(0xe465c7176713655952e4cd0925e3c01b046d9399e14c8fcbea1a9839720e1928);
+
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](3);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(burnable1155_2),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        tokens[1] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 1,
+            itemIndex: 0,
+            contractAddress: address(burnable1155),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        tokens[2] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 2,
+            itemIndex: 1,
+            contractAddress: address(burnable721),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        uint256 burnFee = burnRedeem.MULTI_BURN_FEE();
+
+        // Reverts with burnCount > 1 if 721 is in burnTokens
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidBurnAmount.selector);
+        burnRedeem.burnRedeem{value: burnFee*2}(address(creator), 1, 2, tokens);
+
+        // Passes with burnCount > 1
+        tokens[2].itemIndex = 0;
+        tokens[2].contractAddress = address(burnable1155);
+        tokens[2].id = 2;
+        tokens[2].merkleProof = merkleProofToken2;
+        burnRedeem.burnRedeem{value: burnFee*3}(address(creator), 1, 3, tokens);
+
+        
+        // Ensure tokens are burned/minted
+        assertEq(7, burnable1155.balanceOf(anyone1, 1));
+        assertEq(7, burnable1155.balanceOf(anyone1, 2));
+        assertEq(4, burnable1155_2.balanceOf(anyone1, 1));
+        assertEq(3, creator.balanceOf(anyone1));
+
+        vm.stopPrank();
+    }
+
+    function testBurn1155BurnSpecNone() public {
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(oz1155),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.NONE,
+            amount: 1,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, false);
+        oz1155.mint(anyone1, 1, 3);
+        vm.stopPrank();
+
+        vm.deal(anyone1, 1 ether);
+
+        vm.startPrank(anyone1);
+        oz1155.setApprovalForAll(address(burnRedeem), true);
+
+        bytes32[] memory merkleProof;
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](1);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(oz1155),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        uint256 burnFee = burnRedeem.BURN_FEE();
+
+        // Passes with met requirements
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        // Ensure tokens are burned/minted
+        assertEq(2, oz1155.balanceOf(anyone1, 1));
+        assertEq(1, oz1155.balanceOf(address(0xdead), 1));
+        assertEq(1, creator.balanceOf(anyone1));
+        vm.stopPrank();
+    }
+
+    function testBurn1155BurnSpecOpenzeppelin() public {
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(oz1155Burnable),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.OPENZEPPELIN,
+            amount: 1,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, false);
+        oz1155Burnable.mint(anyone1, 1, 3);
+        vm.stopPrank();
+
+        vm.deal(anyone1, 1 ether);
+
+        vm.startPrank(anyone1);
+        oz1155Burnable.setApprovalForAll(address(burnRedeem), true);
+
+        bytes32[] memory merkleProof;
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](1);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(oz1155Burnable),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        uint256 burnFee = burnRedeem.BURN_FEE();
+
+        // Passes with met requirements
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        // Ensure tokens are burned/minted
+        assertEq(2, oz1155Burnable.balanceOf(anyone1, 1));
+        assertEq(0, oz1155Burnable.balanceOf(address(0xdead), 1));
+        assertEq(1, creator.balanceOf(anyone1));
+        vm.stopPrank();
+    }
+
+    function testRedeemAmountMoreThanOne() public {
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(burnable721),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.NONE,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 2,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, false);
+        burnable721.mintBase(anyone1);
+        vm.stopPrank();
+
+        vm.deal(anyone1, 1 ether);
+
+        vm.startPrank(anyone1);
+        burnable721.setApprovalForAll(address(burnRedeem), true);
+
+        bytes32[] memory merkleProof;
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](1);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(burnable721),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        uint256 burnFee = burnRedeem.BURN_FEE();
+
+        // Passes with met requirements
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        // Ensure tokens are burned/minted
+        assertEq(0, burnable721.balanceOf(anyone1));
+        assertEq(2, creator.balanceOf(anyone1));
+        vm.stopPrank();
+    }
+
+    function testMaliciousSenderReverts() public {
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(burnable721),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.NONE,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        // Burn #1
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, false);
+        // Burn #2
+        items[0].contractAddress = address(burnable1155);
+        items[0].tokenSpec = IBurnRedeemCoreV2.TokenSpec.ERC1155;
+        items[0].amount = 1;
+        burnRedeem.initializeBurnRedeem(address(creator), 2, params, false);
+        // Burn #3
+        items[0].burnSpec = IBurnRedeemCoreV2.BurnSpec.MANIFOLD;
+        burnRedeem.initializeBurnRedeem(address(creator), 3, params, false);
+
+        burnable721.mintBase(anyone1);
+        address[] memory recipients = new address[](1);
+        recipients[0] = anyone1;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 2;
+        string[] memory uris = new string[](1);
+        uris[0] = "";
+        burnable1155.mintBaseNew(recipients, amounts, uris);
+        vm.stopPrank();
+
+        vm.deal(anyone1, 1 ether);
+        vm.deal(anyone2, 1 ether);
+
+        vm.startPrank(anyone1);
+        burnable721.setApprovalForAll(address(burnRedeem), true);
+        burnable1155.setApprovalForAll(address(burnRedeem), true);
+        vm.stopPrank();
+
+        bytes32[] memory merkleProof;
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](1);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(burnable721),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        uint256 burnFee = burnRedeem.BURN_FEE();
+
+        // Reverts when msg.sender is not token owner, but tokens are approved
+        // 721 with no burn
+        vm.prank(anyone2);
+        vm.expectRevert("ERC721: transfer from incorrect owner");
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        // 1155 with no burn
+        tokens[0].contractAddress = address(burnable1155);
+        vm.expectRevert("ERC1155: caller is not token owner or approved");
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 2, 1, tokens);
+        // 1155 with burn
+        vm.expectRevert("Caller is not owner or approved");
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 3, 1, tokens);
+    }
+
+    function testBurnRedeemWithCost() public {
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](2);
+        uint160 cost = 1000000000000000000;
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(burnable721),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        items[1] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(burnable1155),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 1,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: cost,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, false);
+
+        burnable721.mintBase(anyone1);
+        address[] memory recipients = new address[](1);
+        recipients[0] = anyone1;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 10;
+        string[] memory uris = new string[](1);
+        uris[0] = "";
+        burnable1155.mintBaseNew(recipients, amounts, uris);
+        vm.stopPrank();
+
+        vm.deal(anyone1, 10 ether);
+
+        vm.startPrank(anyone1);
+        burnable721.setApprovalForAll(address(burnRedeem), true);
+        burnable1155.setApprovalForAll(address(burnRedeem), true);
+
+        bytes32[] memory merkleProof;
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](1);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(burnable721),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        uint256 burnFee = burnRedeem.BURN_FEE();
+
+        // Reverts due to invalid value
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidPaymentAmount.selector);
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+
+        // Passes with proper value
+        burnRedeem.burnRedeem{value: burnFee+cost}(address(creator), 1, 1, tokens);
+
+        // Passes with burnCount > 1
+        tokens[0].itemIndex = 1;
+        tokens[0].contractAddress = address(burnable1155);
+        burnRedeem.burnRedeem{value: (burnFee+cost)*5}(address(creator), 1, 5, tokens);
+        vm.stopPrank();
+
+        // Check that cost was sent to creator
+        assertEq(cost*6, owner.balance);
+    }
+
+    function testRedeemWithMembership() public {
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(burnable721),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.NONE,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        manifoldMembership.setMember(anyone1, true);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, false);
+        burnable721.mintBase(anyone1);
+        vm.stopPrank();
+
+        vm.startPrank(anyone1);
+        burnable721.setApprovalForAll(address(burnRedeem), true);
+
+        bytes32[] memory merkleProof;
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](1);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(burnable721),
+            id: 1,
+            merkleProof: merkleProof
+        });
+
+        // Passes without burn fee
+        burnRedeem.burnRedeem(address(creator), 1, 1, tokens);
+        // Ensure tokens are burned/minted
+        assertEq(0, burnable721.balanceOf(anyone1));
+        assertEq(1, creator.balanceOf(anyone1));
+        vm.stopPrank();
+    }
+
+    function testMultipleRedemptions() public {
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(burnable721),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 2,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        // Burn #1
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, false);
+        // Burn #2
+        items[0].contractAddress = address(burnable1155);
+        items[0].tokenSpec = IBurnRedeemCoreV2.TokenSpec.ERC1155;
+        items[0].amount = 1;
+        burnRedeem.initializeBurnRedeem(address(creator), 2, params, false);
+
+        burnable721.mintBase(anyone1);
+        address[] memory recipients = new address[](1);
+        recipients[0] = anyone1;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 3;
+        string[] memory uris = new string[](1);
+        uris[0] = "";
+        burnable1155.mintBaseNew(recipients, amounts, uris);
+        vm.stopPrank();
+
+        vm.deal(anyone1, 1 ether);
+        vm.startPrank(anyone1);
+        burnable721.setApprovalForAll(address(burnRedeem), true);
+        burnable1155.setApprovalForAll(address(burnRedeem), true);
+
+        address[] memory addresses = new address[](2);
+        addresses[0] = address(creator);
+        addresses[1] = address(creator);
+
+        uint256[] memory indexes = new uint256[](2);
+        indexes[0] = 1;
+        indexes[1] = 2;
+
+        uint32[] memory burnCounts = new uint32[](2);
+        burnCounts[0] = 1;
+        burnCounts[1] = 3;
+
+        bytes32[] memory merkleProof;
+        IBurnRedeemCoreV2.BurnToken[][] memory allTokens = new IBurnRedeemCoreV2.BurnToken[][](2);
+        IBurnRedeemCoreV2.BurnToken[] memory tokens1 = new IBurnRedeemCoreV2.BurnToken[](1);
+        IBurnRedeemCoreV2.BurnToken[] memory tokens2 = new IBurnRedeemCoreV2.BurnToken[](1);
+
+        tokens1[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(burnable721),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        tokens2[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(burnable1155),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        allTokens[0] = tokens1;
+        allTokens[1] = tokens2;
+        uint256 burnFee = burnRedeem.BURN_FEE();
+
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidPaymentAmount.selector);
+        burnRedeem.burnRedeem{value: burnFee}(addresses, indexes, burnCounts, allTokens);
+
+        // Reverts with mismatching lengths
+        address[] memory singleAddresses = new address[](1);
+        addresses[0] = address(creator);
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidInput.selector);
+        burnRedeem.burnRedeem{value: burnFee*2}(singleAddresses, indexes, burnCounts, allTokens);
+
+        uint256[] memory singleIndexes = new uint256[](1);
+        indexes[0] = 1;
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidInput.selector);
+        burnRedeem.burnRedeem{value: burnFee*2}(addresses, singleIndexes, burnCounts, allTokens);
+
+        uint32[] memory singleBurnCounts = new uint32[](1);
+        burnCounts[0] = 1;
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidInput.selector);
+        burnRedeem.burnRedeem{value: burnFee*2}(addresses, indexes, singleBurnCounts, allTokens);
+
+        IBurnRedeemCoreV2.BurnToken[][] memory singleTokens = new IBurnRedeemCoreV2.BurnToken[][](1);
+        singleTokens[0] = tokens1;
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidInput.selector);
+        burnRedeem.burnRedeem{value: burnFee*2}(addresses, indexes, burnCounts, singleTokens);
+
+        // Reverts with burnCount > 1 for 721
+        burnCounts[0] = 2;
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidBurnAmount.selector);
+        burnRedeem.burnRedeem{value: burnFee*2}(addresses, indexes, burnCounts, allTokens);
+
+        // Passes with multiple redemptions, burnCount > 1 for 1155
+        burnCounts[0] = 1;
+        burnRedeem.burnRedeem{value: burnFee*4}(addresses, indexes, burnCounts, allTokens);
+
+        // However, only 2 redeemed for 1155 because total supply is 2
+        // Excess fee refunded
+        assertEq(1 ether - burnFee*3, anyone1.balance);
+
+        // Check balances
+        assertEq(0, burnable721.balanceOf(anyone1));
+        assertEq(1, burnable1155.balanceOf(anyone1, 1));
+        assertEq(3, creator.balanceOf(anyone1));
+    }
+
+    function testOnERC721Received() public {
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(burnable721),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 2,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, false);
+
+        burnable721.mintBase(anyone1);
+        burnable721_2.mintBase(anyone1);
+        vm.stopPrank();
+
+        // Reverts without membership
+        bytes32[] memory merkleProof;
+        bytes memory data = abi.encode(address(creator), uint256(1), uint256(0), merkleProof);
+        vm.prank(anyone1);
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidInput.selector);
+        burnable721.safeTransferFrom(anyone1, address(burnRedeem), 1, data);
+
+        vm.prank(owner);
+        manifoldMembership.setMember(anyone1, true);
+
+        // Reverts due to the wrong contract
+        vm.prank(anyone1);
+        vm.expectRevert(BurnRedeemLibV2.InvalidBurnToken.selector);
+        burnable721_2.safeTransferFrom(anyone1, address(burnRedeem), 1, data);
+
+        // Passes with right token id
+        vm.prank(anyone1);
+        burnable721.safeTransferFrom(anyone1, address(burnRedeem), 1, data);
+
+        // Ensure tokens are burned/minted
+        assertEq(0, burnable721.balanceOf(anyone1));
+        assertEq(1, creator.balanceOf(anyone1));
+        vm.stopPrank();
+    }
+
+    function testOnERC1155Received() public {
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(burnable1155),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 2,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, false);
+        address[] memory recipients = new address[](1);
+        recipients[0] = anyone1;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 3;
+        string[] memory uris = new string[](1);
+        uris[0] = "";
+        burnable1155.mintBaseNew(recipients, amounts, uris);
+        burnable1155_2.mintBaseNew(recipients, amounts, uris);
+        vm.stopPrank();
+
+        // Reverts without membership
+        bytes32[] memory merkleProof;
+        bytes memory data = abi.encode(address(creator), uint256(1), uint32(1), uint256(0), merkleProof);
+        vm.prank(anyone1);
+        vm.expectRevert("ERC1155: transfer to non-ERC1155Receiver implementer");
+        burnable1155.safeTransferFrom(anyone1, address(burnRedeem), 1, 2, data);
+
+        vm.prank(owner);
+        manifoldMembership.setMember(anyone1, true);
+
+        // Reverts due to the wrong contract
+        vm.prank(anyone1);
+        vm.expectRevert("ERC1155: transfer to non-ERC1155Receiver implementer");
+        burnable1155_2.safeTransferFrom(anyone1, address(burnRedeem), 1, 2, data);
+
+        // Reverts with invalid amount
+        vm.prank(anyone1);
+        vm.expectRevert("ERC1155: transfer to non-ERC1155Receiver implementer");
+        burnable1155.safeTransferFrom(anyone1, address(burnRedeem), 1, 3, data);
+
+        // Passes with right token id
+        vm.prank(anyone1);
+        burnable1155.safeTransferFrom(anyone1, address(burnRedeem), 1, 2, data);
+
+        // Ensure tokens are burned/minted
+        assertEq(1, burnable1155.balanceOf(anyone1, 1));
+        assertEq(1, creator.balanceOf(anyone1));
+        vm.stopPrank();
+    }
+
+    function testOnERC1155ReceivedMultiple() public {
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(burnable1155),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 2,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 3,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, false);
+        address[] memory recipients = new address[](1);
+        recipients[0] = anyone1;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 10;
+        string[] memory uris = new string[](1);
+        uris[0] = "";
+        burnable1155.mintBaseNew(recipients, amounts, uris);
+        burnable1155_2.mintBaseNew(recipients, amounts, uris);
+        vm.stopPrank();
+
+        vm.prank(owner);
+        manifoldMembership.setMember(anyone1, true);
+
+        bytes32[] memory merkleProof;
+        bytes memory data = abi.encode(address(creator), uint256(1), uint32(2), uint256(0), merkleProof);
+        vm.prank(anyone1);
+        burnable1155.safeTransferFrom(anyone1, address(burnRedeem), 1, 4, data);
+
+        // Ensure tokens are burned/minted
+        assertEq(6, burnable1155.balanceOf(anyone1, 1));
+        assertEq(2  , creator.balanceOf(anyone1));
+        vm.stopPrank();
+    }
+
+    function testOnERC1155BatchReceived() public {
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](2);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.RANGE,
+            contractAddress: address(burnable1155),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 2,
+            minTokenId: 1,
+            maxTokenId: 1,
+            merkleRoot: bytes32(0)
+        });
+        items[1] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.RANGE,
+            contractAddress: address(burnable1155),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 2,
+            minTokenId: 2,
+            maxTokenId: 2,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 2,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, false);
+        address[] memory recipients = new address[](1);
+        recipients[0] = anyone1;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 10;
+        string[] memory uris = new string[](1);
+        uris[0] = "";
+        burnable1155.mintBaseNew(recipients, amounts, uris);
+        burnable1155.mintBaseNew(recipients, amounts, uris);
+        burnable1155.mintBaseNew(recipients, amounts, uris);
+        burnable1155_2.mintBaseNew(recipients, amounts, uris);
+        burnable1155_2.mintBaseNew(recipients, amounts, uris);
+        burnable1155_2.mintBaseNew(recipients, amounts, uris);
+        vm.stopPrank();
+
+        bytes32[] memory merkleProof;
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](2);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(burnable1155),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        tokens[1] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 1,
+            contractAddress: address(burnable1155),
+            id: 2,
+            merkleProof: merkleProof
+        });
+        bytes memory data = abi.encode(address(creator), uint256(1), uint32(1), tokens);
+        // Reverts without membership
+        vm.prank(anyone1);
+        uint256[] memory tokenIds = new uint256[](2);
+        tokenIds[0] = 1;
+        tokenIds[1] = 2;
+        uint256[] memory values = new uint256[](2);
+        values[0] = 2;
+        values[1] = 2;
+        vm.expectRevert("ERC1155: transfer to non-ERC1155Receiver implementer");
+        burnable1155.safeBatchTransferFrom(anyone1, address(burnRedeem), tokenIds, values, data);
+
+        vm.prank(owner);
+        manifoldMembership.setMember(anyone1, true);
+
+        // Reverts due to the wrong contract
+        vm.prank(anyone1);
+        vm.expectRevert(abi.encodePacked("ERC1155: transfer to non-ERC1155Receiver implementer"));
+        burnable1155_2.safeBatchTransferFrom(anyone1, address(burnRedeem), tokenIds, values, data);
+
+        // Reverts with mismatching token ids amount
+        vm.prank(anyone1);
+        tokenIds[1] = 3;
+        vm.expectRevert("ERC1155: transfer to non-ERC1155Receiver implementer");
+        burnable1155.safeBatchTransferFrom(anyone1, address(burnRedeem), tokenIds, values, data);
+
+        // Reverts with mismatching values amount
+        vm.prank(anyone1);
+        tokenIds[1] = 2;
+        values[0] = 1;
+        values[1] = 1;
+        vm.expectRevert("ERC1155: transfer to non-ERC1155Receiver implementer");
+        burnable1155.safeBatchTransferFrom(anyone1, address(burnRedeem), tokenIds, values, data);
+
+        // Reverts with extra tokens
+        vm.prank(anyone1);
+        uint256[] memory extraTokenIds = new uint256[](3);
+        extraTokenIds[0] = 1;
+        extraTokenIds[1] = 2;
+        extraTokenIds[2] = 3;
+        uint256[] memory extraValues = new uint256[](3);
+        values[0] = 2;
+        values[1] = 2;
+        vm.expectRevert("ERC1155: transfer to non-ERC1155Receiver implementer");
+        burnable1155.safeBatchTransferFrom(anyone1, address(burnRedeem), extraTokenIds, extraValues, data);
+
+        // Passes with right token id
+        values[0] = 2;
+        values[1] = 2;
+        vm.prank(anyone1);
+        burnable1155.safeBatchTransferFrom(anyone1, address(burnRedeem), tokenIds, values, data);
+
+        // burnCount > 1
+        vm.prank(anyone1);
+        data = abi.encode(address(creator), uint256(1), uint32(4), tokens);
+        // Reverts with insufficient values
+        vm.expectRevert("ERC1155: transfer to non-ERC1155Receiver implementer");
+        burnable1155.safeBatchTransferFrom(anyone1, address(burnRedeem), tokenIds, values, data);
+
+        // Passes with right values
+        vm.prank(anyone1);
+        values[0] = 8;
+        values[1] = 8;
+        burnable1155.safeBatchTransferFrom(anyone1, address(burnRedeem), tokenIds, values, data);
+
+        // Ensure tokens are burned/minted
+        assertEq(0, burnable1155.balanceOf(anyone1, 1));
+        assertEq(0, burnable1155.balanceOf(anyone1, 2));
+        assertEq(5, creator.balanceOf(anyone1));
+        vm.stopPrank();
+    }
+
+
+    function testOnERC1155BatchReceivedDirectCall() public {
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.RANGE,
+            contractAddress: address(burnable721),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 0,
+            minTokenId: 1,
+            maxTokenId: 1,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, false);
+        burnable721.mintBase(anyone1);
+        vm.stopPrank();
+
+        bytes32[] memory merkleProof;
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](1);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(burnable721),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        bytes memory data = abi.encode(address(creator), uint256(1), uint32(1), tokens);
+
+        vm.prank(anyone1);
+        burnable721.setApprovalForAll(address(burnRedeem), true);
+
+        vm.prank(owner);
+        manifoldMembership.setMember(anyone1, true);
+
+        uint256[] memory tokenIds = new uint256[](1);
+        tokenIds[0] = 1;
+        uint256[] memory values = new uint256[](1);
+        values[0] = 0;
+        vm.prank(anyone2);
+        vm.expectRevert(abi.encodePacked(IBurnRedeemCoreV2.InvalidToken.selector, uint256(1)));
+        burnRedeem.onERC1155BatchReceived(anyone2, anyone1, tokenIds, values, data);
+    }
+
+    function testReceiverInvalidInput() public {
+        uint160 cost = 1000000000000000000;
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(burnable721),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 2,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: cost,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        // Burn #1 - burn with cost
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, false);
+        // Burn #2 - zero cost multi set requirement
+        group = new IBurnRedeemCoreV2.BurnGroup[](2);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        group[1] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        params.cost = 0;
+        params.burnSet = group;
+        burnRedeem.initializeBurnRedeem(address(creator), 2, params, false);
+        // Burn #3 - zero cost multi item set
+        items = new IBurnRedeemCoreV2.BurnItem[](2);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.RANGE,
+            contractAddress: address(burnable1155),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 1,
+            minTokenId: 1,
+            maxTokenId: 1,
+            merkleRoot: bytes32(0)
+        });
+        items[1] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.RANGE,
+            contractAddress: address(burnable1155),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 1,
+            minTokenId: 2,
+            maxTokenId: 2,
+            merkleRoot: bytes32(0)
+        });
+        group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0].items = items;
+        group[0].requiredCount = 2;
+        params.cost = 0;
+        params.burnSet = group;
+        burnRedeem.initializeBurnRedeem(address(creator), 3, params, false);
+
+
+        burnable721.mintBase(anyone1);
+        address[] memory recipients = new address[](1);
+        recipients[0] = anyone1;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 1;
+        string[] memory uris = new string[](1);
+        uris[0] = "";
+        burnable1155.mintBaseNew(recipients, amounts, uris);
+        burnable1155.mintBaseNew(recipients, amounts, uris);
+        manifoldMembership.setMember(anyone1, true);
+        vm.stopPrank();
+
+        vm.deal(anyone1, 1 ether);
+        vm.startPrank(anyone1);
+
+        // Receivers revert on burns with cost
+        // onERC721Received
+        bytes32[] memory merkleProof;
+        bytes memory data = abi.encode(address(creator), uint256(1), uint256(0), merkleProof);
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidInput.selector);
+        burnable721.safeTransferFrom(anyone1, address(burnRedeem), 1, data);
+
+        // onERC1155Received
+        data = abi.encode(address(creator), uint256(1), uint32(1), uint256(0), merkleProof);
+        vm.expectRevert("ERC1155: transfer to non-ERC1155Receiver implementer");
+        burnable1155.safeTransferFrom(anyone1, address(burnRedeem), 1, 1, data);
+
+        // onERC1155BatchReceived
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](1);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(burnable1155),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        data = abi.encode(address(creator), uint256(1), uint32(1), tokens);
+        uint256[] memory tokenIds = new uint256[](1);
+        tokenIds[0] = 1;
+        uint256[] memory values = new uint256[](1);
+        values[0] = 1;
+        vm.expectRevert("ERC1155: transfer to non-ERC1155Receiver implementer");
+        burnable1155.safeBatchTransferFrom(anyone1, address(burnRedeem), tokenIds, values, data);
+
+        // Single receivers revert when burnSets.length > 1 (burn #2)
+        data = abi.encode(address(creator), uint256(2), uint256(0), merkleProof);
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidInput.selector);
+        burnable721.safeTransferFrom(anyone1, address(burnRedeem), 1, data);
+        data = abi.encode(address(creator), uint256(2), uint32(1), uint256(0), merkleProof);
+        vm.expectRevert("ERC1155: transfer to non-ERC1155Receiver implementer");
+        burnable1155.safeTransferFrom(anyone1, address(burnRedeem), 1, 1, data);
+
+        // Single receivers revert when requiredCount > 1 (burn #3)
+        data = abi.encode(address(creator), uint256(3), uint256(0), merkleProof);
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidInput.selector);
+        burnable721.safeTransferFrom(anyone1, address(burnRedeem), 1, data);
+        data = abi.encode(address(creator), uint256(3), uint32(1), uint256(0), merkleProof);
+        vm.expectRevert("ERC1155: transfer to non-ERC1155Receiver implementer");
+        burnable1155.safeTransferFrom(anyone1, address(burnRedeem), 1, 1, data);
+    }
+
+    function testMisconfigurationOnERC721Received() public {
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(burnable721),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 1,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, false);
+        manifoldMembership.setMember(anyone1, true);
+        burnable721.mintBase(anyone1);
+        vm.stopPrank();
+        bytes32[] memory merkleProof;
+        bytes memory data = abi.encode(address(creator), uint256(1), uint256(0), merkleProof);
+
+        vm.prank(anyone1);
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidInput.selector);
+        burnable721.safeTransferFrom(anyone1, address(burnRedeem), 1, data);
+    }
+
+    function testMisconfigurationOnERC1155Received() public {
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(burnable1155),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, false);
+        manifoldMembership.setMember(anyone1, true);
+        address[] memory recipients = new address[](1);
+        recipients[0] = anyone1;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 1;
+        string[] memory uris = new string[](1);
+        uris[0] = "";
+        burnable1155.mintBaseNew(recipients, amounts, uris);
+        vm.stopPrank();
+        bytes32[] memory merkleProof;
+        bytes memory data = abi.encode(address(creator), uint256(1), uint256(0), merkleProof);
+
+        vm.prank(anyone1);
+        data = abi.encode(address(creator), uint256(1), uint32(1), uint256(0), merkleProof);
+        vm.expectRevert("ERC1155: transfer to non-ERC1155Receiver implementer");
+        burnable1155.safeTransferFrom(anyone1, address(burnRedeem), 1, 1, data);
+    }
+
+    function testWithdraw() public {
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(burnable721),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, false);
+        for (uint256 i = 0; i < 10; i++) {
+            burnable721.mintBase(anyone1);
+        }
+        vm.stopPrank();
+
+        vm.deal(anyone1, 1 ether);
+        vm.startPrank(anyone1);
+        burnable721.setApprovalForAll(address(burnRedeem), true);
+        address[] memory addresses = new address[](10);
+        uint256[] memory indexes = new uint256[](10);
+        uint32[] memory burnCounts = new uint32[](10);
+        bytes32[] memory merkleProof;
+        IBurnRedeemCoreV2.BurnToken[][] memory allTokens = new IBurnRedeemCoreV2.BurnToken[][](10);
+        for (uint256 i = 0; i < 10; i++) {
+            addresses[i] = address(creator);
+            indexes[i] = 1;
+            burnCounts[i] = 1;
+            IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](1);
+            IBurnRedeemCoreV2.BurnToken memory token = IBurnRedeemCoreV2.BurnToken({
+                groupIndex: 0,
+                itemIndex: 0,
+                contractAddress: address(burnable721),
+                id: i+1,
+                merkleProof: merkleProof
+            });
+            tokens[0] = token;
+            allTokens[i] = tokens;
+        }
+        uint256 burnFee = burnRedeem.BURN_FEE();
+        burnRedeem.burnRedeem{value: burnFee*10}(addresses, indexes, burnCounts, allTokens);
+        vm.stopPrank();
+
+        vm.prank(anyone2);
+        vm.expectRevert("AdminControl: Must be owner or admin");
+        burnRedeem.withdraw(payable(anyone2), burnFee*10);
+
+        vm.prank(burnRedeemOwner);
+        vm.expectRevert();
+        burnRedeem.withdraw(payable(owner), burnFee*11);
+
+        vm.prank(burnRedeemOwner);
+        burnRedeem.withdraw(payable(owner), burnFee*10);
+        assertEq(burnFee*10, owner.balance);
+    }
+
+    function testAirdrop() public {
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(burnable721),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 2,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, false);
+        vm.stopPrank();
+
+        address[] memory recipients = new address[](2);
+        recipients[0] = anyone1;
+        recipients[1] = anyone2;
+        uint32[] memory amounts = new uint32[](2);
+        amounts[0] = 1;
+        amounts[1] = 1;
+
+        vm.prank(anyone1);
+        vm.expectRevert(abi.encodePacked(IBurnRedeemCoreV2.NotAdmin.selector, uint256(uint160(address(creator)))));
+        burnRedeem.airdrop(address(creator), 1, recipients, amounts);
+
+        vm.prank(owner);
+        burnRedeem.airdrop(address(creator), 1, recipients, amounts);
+
+        // Check the token uri
+        assertEq(creator.tokenURI(1), "XXX/1");
+        assertEq(creator.tokenURI(2), "XXX/2");
+
+        // Check balances
+        assertEq(2, creator.balanceOf(anyone1));
+        assertEq(2, creator.balanceOf(anyone2));
+
+        // redeemedCount updated
+        IBurnRedeemCoreV2.BurnRedeem memory burnInstance = burnRedeem.getBurnRedeem(address(creator), 1);
+        assertEq(burnInstance.redeemedCount, 4);
+        assertEq(burnInstance.totalSupply, 10);
+
+        // Second airdrop
+        amounts[0] = 9;
+        amounts[1] = 9;
+        vm.prank(owner);
+        burnRedeem.airdrop(address(creator), 1, recipients, amounts);
+
+        // check amounts
+        burnInstance = burnRedeem.getBurnRedeem(address(creator), 1);
+        assertEq(burnInstance.redeemedCount, 40);
+        assertEq(burnInstance.totalSupply, 40);
+
+        // Check balances
+        assertEq(20, creator.balanceOf(anyone1));
+        assertEq(20, creator.balanceOf(anyone2));
+
+        // Reverts when redeemedCount would exceed max uint32
+        recipients = new address[](1);
+        recipients[0] = anyone1;
+        amounts = new uint32[](1);
+        amounts[0] = 2147483647;
+        vm.prank(owner);
+        vm.expectRevert(IBurnRedeemCoreV2.InvalidRedeemAmount.selector);
+        burnRedeem.airdrop(address(creator), 1, recipients, amounts);
+    }
+
+
+    function testSetBurnFees() public {
+        uint256 newBurnFee = defaultBurnFee + 1000000;
+        uint256 newMultiBurnFee = defaultMultiBurnFee + 1000000;
+
+         // Owner can set fees
+        vm.prank(burnRedeemOwner);
+        burnRedeem.setBurnFees(newBurnFee, newMultiBurnFee);
+
+        // Verify fees were set correctly
+        assertEq(burnRedeem.BURN_FEE(), newBurnFee);
+        assertEq(burnRedeem.MULTI_BURN_FEE(), newMultiBurnFee);
+
+        // test burns with new fees
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](6);
+         // tokenSpec: ERC-721, burnSpec: NONE
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
+            contractAddress: address(0),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.NONE,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        // tokenSpec: ERC-721, burnSpec: MANIFOLD
+        items[1] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
+            contractAddress: address(0),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        // tokenSpec: ERC-721, burnSpec: OPENZEPPELIN
+        items[2] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
+            contractAddress: address(0),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.OPENZEPPELIN,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        // tokenSpec: ERC-1155, burnSpec: NONE
+        items[3] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
+            contractAddress: address(0),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.NONE,
+            amount: 1,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        // tokenSpec: ERC-1155, burnSpec: MANIFOLD
+        items[4] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
+            contractAddress: address(0),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 1,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        // tokenSpec: ERC-1155, burnSpec: OPENZEPPELIN
+        items[5] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
+            contractAddress: address(0),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.OPENZEPPELIN,
+            amount: 1,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, true);
+
+        // Mint tokens to anyone1
+        oz721.mint(anyone1, 1);
+        burnable721.mintBase(anyone1);
+        oz721Burnable.mint(anyone1, 1);
+        oz1155.mint(anyone1, 1, 1);
+        address[] memory recipients = new address[](1);
+        recipients[0] = anyone1;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 1;
+        string[] memory uris = new string[](1);
+        uris[0] = "";
+        burnable1155.mintBaseNew(recipients, amounts, uris);
+        oz1155Burnable.mint(anyone1, 1, 1);
+
+        vm.stopPrank();
+
+        vm.deal(anyone1, 1 ether);
+        bytes32[] memory merkleProof;
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](1);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(0),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        uint256 burnFee = newBurnFee;
+
+        vm.startPrank(anyone1);
+        oz721.setApprovalForAll(address(burnRedeem), true);
+        tokens[0].contractAddress = address(oz721);
+        tokens[0].itemIndex = 0;
+        vm.expectRevert();
+        burnRedeem.burnRedeem{value: defaultBurnFee}(address(creator), 1, 1, tokens);
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        assertEq(0, oz721.balanceOf(anyone1));
+        assertEq(1, oz721.balanceOf(address(0x000000000000000000000000000000000000dEaD)));
+
+        burnable721.setApprovalForAll(address(burnRedeem), true);
+        tokens[0].contractAddress = address(burnable721);
+        tokens[0].itemIndex = 1;
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        vm.expectRevert("ERC721: invalid token ID");
+        burnable721.ownerOf(1);
+
+        oz721Burnable.setApprovalForAll(address(burnRedeem), true);
+        tokens[0].contractAddress = address(oz721Burnable);
+        tokens[0].itemIndex = 2;
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        vm.expectRevert("ERC721: invalid token ID");
+        oz721Burnable.ownerOf(1);
+
+        oz1155.setApprovalForAll(address(burnRedeem), true);
+        tokens[0].contractAddress = address(oz1155);
+        tokens[0].itemIndex = 3;
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        assertEq(0, oz1155.balanceOf(anyone1, 1));
+        assertEq(1, oz1155.balanceOf(address(0x000000000000000000000000000000000000dEaD), 1));
+
+        burnable1155.setApprovalForAll(address(burnRedeem), true);
+        tokens[0].contractAddress = address(burnable1155);
+        tokens[0].itemIndex = 4;
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        assertEq(0, burnable1155.balanceOf(anyone1, 1));
+        assertEq(0, burnable1155.totalSupply(1));
+
+        oz1155Burnable.setApprovalForAll(address(burnRedeem), true);
+        tokens[0].contractAddress = address(oz1155Burnable);
+        tokens[0].itemIndex = 5;
+        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
+        assertEq(0, oz1155Burnable.balanceOf(anyone1, 1));
+        assertEq(0, oz1155Burnable.balanceOf(address(0x000000000000000000000000000000000000dEaD), 1));
+
+        vm.stopPrank();
+    }
+
+    function testSetActive() public {
+       // stop new burns from being initialized
+        vm.startPrank(burnRedeemOwner);
+        burnRedeem.setActive(false);
+        vm.stopPrank();
+
+        vm.startPrank(owner);
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
+        items[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(burnable1155),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 1,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        IBurnRedeemCoreV2.BurnGroup[] memory group = new IBurnRedeemCoreV2.BurnGroup[](1);
+        group[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 1,
+            items: items
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory params = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 2,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: group
+        });
+        vm.expectRevert(IBurnRedeemCoreV2.Inactive.selector);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, true);
+        vm.stopPrank();
+
+        // resume new burns
+        vm.startPrank(burnRedeemOwner);
+        burnRedeem.setActive(true);
+        vm.stopPrank();
+
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 1, params, true);
+        vm.stopPrank();
+
+        // can still burn even if claim creations are paused
+        vm.startPrank(burnRedeemOwner);
+        burnRedeem.setActive(false);
+        vm.stopPrank();
+
+        vm.startPrank(owner);
+        address[] memory recipients = new address[](1);
+        recipients[0] = anyone1;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 3;
+        string[] memory uris = new string[](1);
+        uris[0] = "";
+
+        uint256[] memory tokenIds = burnable1155.mintBaseNew(recipients, amounts, uris);
+
+        // check they own 3x 1155 tokens
+        assertEq(burnable1155.balanceOf(anyone1, tokenIds[0]), 3);
+
+        vm.stopPrank();
+        
+        vm.startPrank(anyone1);
+
+        vm.deal(anyone1, 1 ether);
+        IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](1);
+        tokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(burnable1155),
+            id: tokenIds[0],
+            merkleProof: new bytes32[](0)
+        });
+        burnable1155.setApprovalForAll(address(burnRedeem), true);
+        burnRedeem.burnRedeem{value: defaultBurnFee}(address(creator), 1, 1, tokens);
+        vm.stopPrank();
+
+    }
+
+}

--- a/packages/manifold/test/burnredeemUpdatableFee/ERC721BurnRedeemV2.t.sol
+++ b/packages/manifold/test/burnredeemUpdatableFee/ERC721BurnRedeemV2.t.sol
@@ -2427,68 +2427,12 @@ contract ManifoldERC721BurnRedeemV2Test is Test {
         assertEq(burnRedeem.MULTI_BURN_FEE(), newMultiBurnFee);
 
         // test burns with new fees
-        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](6);
-         // tokenSpec: ERC-721, burnSpec: NONE
+        IBurnRedeemCoreV2.BurnItem[] memory items = new IBurnRedeemCoreV2.BurnItem[](1);
         items[0] = IBurnRedeemCoreV2.BurnItem({
-            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
-            contractAddress: address(0),
-            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
-            burnSpec: IBurnRedeemCoreV2.BurnSpec.NONE,
-            amount: 0,
-            minTokenId: 0,
-            maxTokenId: 0,
-            merkleRoot: bytes32(0)
-        });
-        // tokenSpec: ERC-721, burnSpec: MANIFOLD
-        items[1] = IBurnRedeemCoreV2.BurnItem({
-            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
-            contractAddress: address(0),
-            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
-            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
-            amount: 0,
-            minTokenId: 0,
-            maxTokenId: 0,
-            merkleRoot: bytes32(0)
-        });
-        // tokenSpec: ERC-721, burnSpec: OPENZEPPELIN
-        items[2] = IBurnRedeemCoreV2.BurnItem({
-            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
-            contractAddress: address(0),
-            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
-            burnSpec: IBurnRedeemCoreV2.BurnSpec.OPENZEPPELIN,
-            amount: 0,
-            minTokenId: 0,
-            maxTokenId: 0,
-            merkleRoot: bytes32(0)
-        });
-        // tokenSpec: ERC-1155, burnSpec: NONE
-        items[3] = IBurnRedeemCoreV2.BurnItem({
-            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
-            contractAddress: address(0),
-            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
-            burnSpec: IBurnRedeemCoreV2.BurnSpec.NONE,
-            amount: 1,
-            minTokenId: 0,
-            maxTokenId: 0,
-            merkleRoot: bytes32(0)
-        });
-        // tokenSpec: ERC-1155, burnSpec: MANIFOLD
-        items[4] = IBurnRedeemCoreV2.BurnItem({
-            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
-            contractAddress: address(0),
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(burnable1155),
             tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
             burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
-            amount: 1,
-            minTokenId: 0,
-            maxTokenId: 0,
-            merkleRoot: bytes32(0)
-        });
-        // tokenSpec: ERC-1155, burnSpec: OPENZEPPELIN
-        items[5] = IBurnRedeemCoreV2.BurnItem({
-            validationType: IBurnRedeemCoreV2.ValidationType.ANY,
-            contractAddress: address(0),
-            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
-            burnSpec: IBurnRedeemCoreV2.BurnSpec.OPENZEPPELIN,
             amount: 1,
             minTokenId: 0,
             maxTokenId: 0,
@@ -2514,77 +2458,101 @@ contract ManifoldERC721BurnRedeemV2Test is Test {
         burnRedeem.initializeBurnRedeem(address(creator), 1, params, true);
 
         // Mint tokens to anyone1
-        oz721.mint(anyone1, 1);
-        burnable721.mintBase(anyone1);
-        oz721Burnable.mint(anyone1, 1);
-        oz1155.mint(anyone1, 1, 1);
         address[] memory recipients = new address[](1);
         recipients[0] = anyone1;
         uint256[] memory amounts = new uint256[](1);
-        amounts[0] = 1;
+        amounts[0] = 3;
         string[] memory uris = new string[](1);
         uris[0] = "";
         burnable1155.mintBaseNew(recipients, amounts, uris);
-        oz1155Burnable.mint(anyone1, 1, 1);
-
+        burnable721.mintBase(anyone1);
         vm.stopPrank();
 
-        vm.deal(anyone1, 1 ether);
+        vm.startPrank(anyone1);
+        vm.deal(anyone1, 3 ether);
         bytes32[] memory merkleProof;
         IBurnRedeemCoreV2.BurnToken[] memory tokens = new IBurnRedeemCoreV2.BurnToken[](1);
         tokens[0] = IBurnRedeemCoreV2.BurnToken({
             groupIndex: 0,
             itemIndex: 0,
-            contractAddress: address(0),
+            contractAddress: address(burnable1155),
             id: 1,
             merkleProof: merkleProof
         });
-        uint256 burnFee = newBurnFee;
 
-        vm.startPrank(anyone1);
-        oz721.setApprovalForAll(address(burnRedeem), true);
-        tokens[0].contractAddress = address(oz721);
-        tokens[0].itemIndex = 0;
-        vm.expectRevert();
-        burnRedeem.burnRedeem{value: defaultBurnFee}(address(creator), 1, 1, tokens);
-        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
-        assertEq(0, oz721.balanceOf(anyone1));
-        assertEq(1, oz721.balanceOf(address(0x000000000000000000000000000000000000dEaD)));
-
-        burnable721.setApprovalForAll(address(burnRedeem), true);
-        tokens[0].contractAddress = address(burnable721);
-        tokens[0].itemIndex = 1;
-        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
-        vm.expectRevert("ERC721: invalid token ID");
-        burnable721.ownerOf(1);
-
-        oz721Burnable.setApprovalForAll(address(burnRedeem), true);
-        tokens[0].contractAddress = address(oz721Burnable);
-        tokens[0].itemIndex = 2;
-        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
-        vm.expectRevert("ERC721: invalid token ID");
-        oz721Burnable.ownerOf(1);
-
-        oz1155.setApprovalForAll(address(burnRedeem), true);
-        tokens[0].contractAddress = address(oz1155);
-        tokens[0].itemIndex = 3;
-        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
-        assertEq(0, oz1155.balanceOf(anyone1, 1));
-        assertEq(1, oz1155.balanceOf(address(0x000000000000000000000000000000000000dEaD), 1));
 
         burnable1155.setApprovalForAll(address(burnRedeem), true);
-        tokens[0].contractAddress = address(burnable1155);
-        tokens[0].itemIndex = 4;
-        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
-        assertEq(0, burnable1155.balanceOf(anyone1, 1));
-        assertEq(0, burnable1155.totalSupply(1));
+        burnable721.setApprovalForAll(address(burnRedeem), true);
+        // should revert because the burn set is not satisfied
+        vm.expectRevert();
+        burnRedeem.burnRedeem{value: defaultBurnFee}(address(creator), 1, 1, tokens);
 
-        oz1155Burnable.setApprovalForAll(address(burnRedeem), true);
-        tokens[0].contractAddress = address(oz1155Burnable);
-        tokens[0].itemIndex = 5;
-        burnRedeem.burnRedeem{value: burnFee}(address(creator), 1, 1, tokens);
-        assertEq(0, oz1155Burnable.balanceOf(anyone1, 1));
-        assertEq(0, oz1155Burnable.balanceOf(address(0x000000000000000000000000000000000000dEaD), 1));
+        burnRedeem.burnRedeem{value: newBurnFee}(address(creator), 1, 1, tokens);
+        vm.stopPrank();
+
+        // multi tokens burn
+        IBurnRedeemCoreV2.BurnItem[] memory multiItems = new IBurnRedeemCoreV2.BurnItem[](2);
+        multiItems[0] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(burnable1155),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC1155,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 1,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        multiItems[1] = IBurnRedeemCoreV2.BurnItem({
+            validationType: IBurnRedeemCoreV2.ValidationType.CONTRACT,
+            contractAddress: address(burnable721),
+            tokenSpec: IBurnRedeemCoreV2.TokenSpec.ERC721,
+            burnSpec: IBurnRedeemCoreV2.BurnSpec.MANIFOLD,
+            amount: 0,
+            minTokenId: 0,
+            maxTokenId: 0,
+            merkleRoot: bytes32(0)
+        });
+        
+        IBurnRedeemCoreV2.BurnGroup[] memory multiGroup = new IBurnRedeemCoreV2.BurnGroup[](1);
+        multiGroup[0] = IBurnRedeemCoreV2.BurnGroup({
+            requiredCount: 2,
+            items: multiItems
+        });
+        IBurnRedeemCoreV2.BurnRedeemParameters memory multiParams = IBurnRedeemCoreV2.BurnRedeemParameters({
+            paymentReceiver: payable(owner),
+            storageProtocol: IBurnRedeemCoreV2.StorageProtocol.NONE,
+            redeemAmount: 1,
+            totalSupply: 10,
+            startDate: uint48(block.timestamp - 30),
+            endDate: uint48(block.timestamp + 1000),
+            cost: 0,
+            location: "XXX",
+            burnSet: multiGroup
+        });
+        vm.startPrank(owner);
+        burnRedeem.initializeBurnRedeem(address(creator), 2, multiParams, true);
+        IBurnRedeemCoreV2.BurnToken[] memory multiTokens = new IBurnRedeemCoreV2.BurnToken[](2);
+        multiTokens[0] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 0,
+            contractAddress: address(burnable1155),
+            id: 1,
+            merkleProof: merkleProof
+        });
+        multiTokens[1] = IBurnRedeemCoreV2.BurnToken({
+            groupIndex: 0,
+            itemIndex: 1,
+            contractAddress: address(burnable721),
+            id: 1,
+            merkleProof: merkleProof
+        });
+
+        vm.startPrank(anyone1);
+        // should revert because the burn set is not satisfied
+        vm.expectRevert();
+        burnRedeem.burnRedeem{value: defaultMultiBurnFee}(address(creator), 2, 1, multiTokens);
+
+        burnRedeem.burnRedeem{value: newMultiBurnFee}(address(creator), 2, 1, multiTokens);
 
         vm.stopPrank();
     }

--- a/packages/manifold/test/burnredeemUpdatableFee/ERC721BurnRedeemV2.t.sol
+++ b/packages/manifold/test/burnredeemUpdatableFee/ERC721BurnRedeemV2.t.sol
@@ -2548,7 +2548,7 @@ contract ManifoldERC721BurnRedeemV2Test is Test {
         });
 
         vm.startPrank(anyone1);
-        // should revert because the burn set is not satisfied
+        // should revert because not enough burn fees
         vm.expectRevert();
         burnRedeem.burnRedeem{value: defaultMultiBurnFee}(address(creator), 2, 1, multiTokens);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## This PR

<!-- Please give us a rough overview of the PR's changes here. -->
Add new ERC721BurnRedeemV2 and ERC1155BurnRedeemV2
Has exact same functionality as ERC721BurnRedeem and ERC1155BurnRedeem except the ability to update mintFees and prevent new burns if neccessary

New methods:
+ `setBurnFees`: set burn fees, takes in `burnFee` and `multiBurnFee`. Only admin of the extension can trigger
+ `setActive`: whether to allow new burns or not. Only admin of the extension can trigger

New tests for `setBurnFees` and `setActive`

### Screenshots (if applicable)
<!-- If this PR is UI related, please provide screenshots of the changes. -->


### Ticket

https://linear.app/manifoldxyz/issue/UPDATE-THIS-PART

## Self-Review
<!-- Ensure you have done the following before requesting a review: -->
- [ ] Review and comment PR file changes
- [x] Description provides context for the changes
- [x] Tests are included for the PR (required on server changes)


## CR Notes

<!-- Please give any technical notes for the reviewer here. -->

## QA Steps

<!-- Please fill out any QA steps the tester can follow here. -->

- [ ]
