### PR TITLE
Add Deck claims extension for ERC1155

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
-      - name: Set Node to v18
+      - name: Set Node to v20
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
 
       - name: Install truffle
         run: |
@@ -71,10 +71,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
-      - name: Set Node to v8
+      - name: Set Node to v20
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/packages/manifold/CLAUDE.md
+++ b/packages/manifold/CLAUDE.md
@@ -1,0 +1,143 @@
+# CLAUDE.md - AI Assistant Guidelines
+
+## Project Overview
+**Manifold Creator Core Extensions** - Solidity smart contracts providing extension functionality for [Manifold Creator Core](https://github.com/manifoldxyz/creator-core-solidity) NFT contracts deployed via [Manifold Studio](https://studio.manifold.xyz).
+
+These are **shared extensions** - single deployed instances that any Manifold Creator contract can install for enhanced functionality.
+
+## Tech Stack
+- **Language**: Solidity ^0.8.17
+- **Framework**: Foundry (primary), Truffle (legacy tests)
+- **Dependencies**:
+  - `@manifoldxyz/creator-core-solidity` ^3.0.0
+  - OpenZeppelin contracts
+- **Test Framework**: Foundry (`forge test`)
+- **Build**: `forge build`
+
+## Project Structure
+```
+contracts/
+├── burnredeem/          # Burn-to-redeem NFT mechanics
+├── burnredeemUpdatableFee/  # V2 with updatable fees
+├── collectible/         # Collectible extensions (ERC721)
+├── crossChainBurn/      # Cross-chain burn functionality
+├── edition/             # ERC721 batch minting editions
+├── frameclaims/         # Farcaster Frame claim extensions
+├── gachaclaims/         # Serendipity/gacha mechanics
+├── lazyclaim/           # Lazy payable claim pages (ETH)
+├── lazyUpdatableFeeClaim/  # V2 lazy claims with updatable fees
+├── libraries/           # Shared libraries & interfaces
+├── metadata/            # Frozen metadata extensions
+├── operatorfilterer/    # OpenSea operator filter support
+├── physicalclaim/       # Physical item redemption
+├── single/              # Single-creator extensions
+└── soulbound/           # Soulbound token extensions
+test/                    # Foundry tests (.t.sol) & Truffle tests (.js)
+script/                  # Foundry deployment scripts (.s.sol)
+```
+
+## Key Extension Types
+
+### Lazy Claim (Claim Pages)
+- `LazyPayableClaimCore.sol` - Base logic for payable claims
+- Supports merkle tree allowlists
+- Delegation registry integration (v1 & v2)
+- Signature-based minting
+- ERC721 and ERC1155 variants
+
+### Burn Redeem
+- Burn existing NFTs to mint new ones
+- Supports multiple burn token types
+- ERC721 and ERC1155 output variants
+
+### Serendipity (Gacha)
+- Randomized NFT minting mechanics
+- Supply management with limited/unlimited modes
+
+## Development Commands
+```bash
+# Install dependencies
+npm install
+
+# Build contracts
+forge build
+
+# Run all tests
+forge test
+
+# Run specific test file
+forge test --match-path test/lazyclaim/ERC721LazyPayableClaim.t.sol
+
+# Run with verbosity
+forge test -vvv
+
+# Lint
+npm run lint
+```
+
+## Code Patterns & Conventions
+
+### Contract Architecture
+- Extensions inherit from `AdminControl` for access control
+- Use `creatorAdminRequired` modifier for creator-specific operations
+- Abstract base contracts with ERC721/ERC1155 concrete implementations
+- Interface contracts prefixed with `I` (e.g., `ILazyPayableClaimCore`)
+
+### Naming Conventions
+- Core/base contracts: `*Core.sol`
+- ERC721 implementations: `ERC721*.sol`
+- ERC1155 implementations: `ERC1155*.sol`
+- Interfaces: `I*.sol`
+- V2 contracts in separate directories with `V2` suffix
+
+### Gas Optimization Patterns
+```solidity
+// Unchecked increments in loops
+unchecked { ++i; }
+
+// Bitmask tracking for merkle mints
+uint256 internal constant MINT_INDEX_BITMASK = 0xFF;
+
+// Max value constants
+uint256 internal constant MAX_UINT_24 = 0xffffff;
+```
+
+### Common Imports
+```solidity
+import "@manifoldxyz/libraries-solidity/contracts/access/AdminControl.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+```
+
+### Custom Errors
+Use custom errors instead of require strings:
+```solidity
+revert ILazyPayableClaimCore.ClaimInactive();
+revert ILazyPayableClaimCore.InvalidInput();
+```
+
+## Testing Patterns
+- Foundry tests in `test/**/*.t.sol`
+- Mock contracts in `test/mocks/`
+- Delegation registry mocks available
+- Legacy Truffle tests in `.js` files
+
+## Deployment
+- Scripts in `script/*.s.sol`
+- Multi-network support (Mainnet, Goerli, Sepolia, Base)
+- Addresses documented in README.md
+
+## Solhint Rules
+- Compiler version: ^0.8.0
+- `not-rely-on-time`: off (timestamps used for claim windows)
+- `no-empty-blocks`: off
+
+## Context Summary
+This is a mature Solidity codebase for NFT creator extensions. When making changes:
+1. Follow existing patterns for new extensions
+2. Create both interface and implementation contracts
+3. Support both ERC721 and ERC1155 where applicable
+4. Include Foundry tests
+5. Use custom errors over require strings
+6. Apply gas optimizations (unchecked loops, bitmasks)

--- a/packages/manifold/contracts/deckClaims/Deck.sol
+++ b/packages/manifold/contracts/deckClaims/Deck.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+// solhint-disable reason-string
+pragma solidity ^0.8.0;
+
+import "@manifoldxyz/libraries-solidity/contracts/access/AdminControl.sol";
+
+import "./IDeck.sol";
+
+/**
+ * @title Deck Lazy Claim
+ * @author manifold.xyz
+ */
+abstract contract Deck is IDeck, AdminControl {
+  using EnumerableSet for EnumerableSet.AddressSet;
+
+  string internal constant ARWEAVE_PREFIX = "https://arweave.net/";
+  string internal constant IPFS_PREFIX = "ipfs://";
+  address internal _signer;
+
+  uint256 internal constant MAX_UINT_8 = 0xff;
+  uint256 internal constant MAX_UINT_32 = 0xffffffff;
+  uint256 internal constant MAX_UINT_56 = 0xffffffffffffff;
+  uint256 internal constant MAX_UINT_80 = 0xffffffffffffffffffff;
+  address internal constant ADDRESS_ZERO = 0x0000000000000000000000000000000000000000;
+
+  bool public deprecated;
+
+  /**
+   * @notice This extension is shared, not single-creator. So we must ensure
+   * that a claim's initializer is an admin on the creator contract
+   * @param creatorContractAddress    the address of the creator contract to check the admin against
+   */
+  modifier creatorAdminRequired(address creatorContractAddress) {
+    AdminControl creatorCoreContract = AdminControl(creatorContractAddress);
+    require(creatorCoreContract.isAdmin(msg.sender), "Wallet is not an administrator for contract");
+    _;
+  }
+
+  constructor(address initialOwner) {
+    _transferOwnership(initialOwner);
+  }
+
+  /**
+   * Admin function to deprecate the contract
+   */
+  function deprecate(bool _deprecated) external adminRequired {
+    deprecated = _deprecated;
+  }
+
+  /**
+   * See {IDeck-withdraw}.
+   */
+  function withdraw(address payable receiver, uint256 amount) external override adminRequired {
+    (bool sent, ) = receiver.call{ value: amount }("");
+    if (!sent) revert IDeck.FailedToTransfer();
+  }
+
+  /**
+   * See {IDeck-setSigner}.
+   */
+  function setSigner(address signer) external override adminRequired {
+    _signer = signer;
+  }
+
+  function _validateSigner() internal view {
+    if (msg.sender != _signer) revert IDeck.InvalidSignature();
+  }
+}

--- a/packages/manifold/contracts/deckClaims/ERC1155Deck.sol
+++ b/packages/manifold/contracts/deckClaims/ERC1155Deck.sol
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: MIT
+// solhint-disable reason-string
+pragma solidity ^0.8.0;
+
+import "@manifoldxyz/creator-core-solidity/contracts/core/IERC1155CreatorCore.sol";
+import "@manifoldxyz/creator-core-solidity/contracts/extensions/ICreatorExtensionTokenURI.sol";
+
+import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
+
+import "./Deck.sol";
+import "./IERC1155Deck.sol";
+
+/**
+ * @title Deck Lazy Payable Claim - ERC-1155
+ * @author manifold.xyz
+ * @notice
+ */
+contract ERC1155Deck is IERC165, IERC1155Deck, ICreatorExtensionTokenURI, Deck {
+  using Strings for uint256;
+
+  // stores mapping from contractAddress/instanceId to the claim it represents
+  // { contractAddress => { instanceId => Claim } }
+  mapping(address => mapping(uint256 => Claim)) private _claims;
+
+  // { contractAddress => { tokenId => { instanceId } }
+  mapping(address => mapping(uint256 => uint256)) private _tokenInstances;
+
+  function supportsInterface(bytes4 interfaceId) public view virtual override(IERC165, AdminControl) returns (bool) {
+    return
+      interfaceId == type(IERC1155Deck).interfaceId ||
+      interfaceId == type(IDeck).interfaceId ||
+      interfaceId == type(ICreatorExtensionTokenURI).interfaceId ||
+      interfaceId == type(IAdminControl).interfaceId ||
+      interfaceId == type(IERC165).interfaceId;
+  }
+
+  constructor(address initialOwner) Deck(initialOwner) {}
+
+  /**
+   * See {IERC1155Deck-initializeClaim}.
+   */
+  function initializeClaim(
+    address creatorContractAddress,
+    uint256 instanceId,
+    ClaimParameters calldata claimParameters
+  ) external payable override creatorAdminRequired(creatorContractAddress) {
+    if (deprecated) {
+      revert ContractDeprecated();
+    }
+    if (instanceId == 0 || instanceId > MAX_UINT_56) revert IDeck.InvalidInstance();
+    if (_claims[creatorContractAddress][instanceId].storageProtocol != StorageProtocol.INVALID)
+      revert IDeck.ClaimAlreadyInitialized();
+    if (claimParameters.storageProtocol == StorageProtocol.INVALID) revert IDeck.InvalidStorageProtocol();
+    if (claimParameters.tokenVariations > MAX_UINT_8) revert IDeck.InvalidInput();
+
+    address[] memory receivers = new address[](1);
+    receivers[0] = msg.sender;
+    uint256[] memory amounts = new uint256[](claimParameters.tokenVariations);
+    string[] memory uris = new string[](claimParameters.tokenVariations);
+    uint256[] memory newTokenIds = IERC1155CreatorCore(creatorContractAddress).mintExtensionNew(receivers, amounts, uris);
+
+    if (newTokenIds[0] > MAX_UINT_80) revert IDeck.InvalidStartingTokenId();
+
+    // Create the claim
+    _claims[creatorContractAddress][instanceId] = Claim({
+      storageProtocol: claimParameters.storageProtocol,
+      total: 0,
+      startingTokenId: uint80(newTokenIds[0]),
+      tokenVariations: claimParameters.tokenVariations,
+      location: claimParameters.location
+    });
+    for (uint256 i; i < claimParameters.tokenVariations; ) {
+      _tokenInstances[creatorContractAddress][newTokenIds[i]] = instanceId;
+      unchecked {
+        ++i;
+      }
+    }
+
+    emit DeckClaimInitialized(creatorContractAddress, instanceId, msg.sender);
+  }
+
+  /**
+   * See {IERC1155Deck-updateClaim}.
+   */
+  function updateClaim(
+    address creatorContractAddress,
+    uint256 instanceId,
+    UpdateClaimParameters calldata updateClaimParameters
+  ) external override creatorAdminRequired(creatorContractAddress) {
+    if (deprecated) {
+      revert ContractDeprecated();
+    }
+    Claim memory claim = _getClaim(creatorContractAddress, instanceId);
+    if (instanceId == 0 || instanceId > MAX_UINT_56) revert IDeck.InvalidInstance();
+    if (updateClaimParameters.storageProtocol == StorageProtocol.INVALID) revert IDeck.InvalidStorageProtocol();
+
+    // Overwrite the existing values
+    _claims[creatorContractAddress][instanceId] = Claim({
+      storageProtocol: updateClaimParameters.storageProtocol,
+      total: claim.total,
+      startingTokenId: claim.startingTokenId,
+      tokenVariations: claim.tokenVariations,
+      location: updateClaimParameters.location
+    });
+    emit DeckClaimUpdated(creatorContractAddress, instanceId);
+  }
+
+  /**
+   * See {IERC1155Deck-getClaim}.
+   */
+  function getClaim(address creatorContractAddress, uint256 instanceId) public view override returns (Claim memory) {
+    return _getClaim(creatorContractAddress, instanceId);
+  }
+
+  /**
+   * See {IERC1155Deck-getClaimForToken}.
+   */
+  function getClaimForToken(
+    address creatorContractAddress,
+    uint256 tokenId
+  ) external view override returns (uint256 instanceId, Claim memory claim) {
+    instanceId = _tokenInstances[creatorContractAddress][tokenId];
+    claim = _getClaim(creatorContractAddress, instanceId);
+  }
+
+  function _getClaim(address creatorContractAddress, uint256 instanceId) private view returns (Claim storage claim) {
+    claim = _claims[creatorContractAddress][instanceId];
+    if (claim.storageProtocol == StorageProtocol.INVALID) revert IDeck.ClaimNotInitialized();
+  }
+
+  /**
+   * See {IDeck-deliverMints}.
+   */
+  function deliverMints(IDeck.ClaimMint[] calldata mints) external override {
+    _validateSigner();
+    for (uint256 i; i < mints.length; ) {
+      ClaimMint calldata mintData = mints[i];
+       Claim memory claim = _getClaim(mintData.creatorContractAddress, mintData.instanceId);
+      address[] memory receivers = new address[](mintData.variationMints.length);
+      uint256[] memory amounts = new uint256[](mintData.variationMints.length);
+      uint256[] memory tokenIds = new uint256[](mintData.variationMints.length);
+      uint32 totalMinted;
+
+      for (uint256 j; j < mintData.variationMints.length; ) {
+        VariationMint calldata variationMint = mintData.variationMints[j];
+        if (variationMint.variationIndex > MAX_UINT_8) revert IDeck.InvalidVariationIndex();
+        uint8 variationIndex = variationMint.variationIndex;
+        if (variationIndex > claim.tokenVariations || variationIndex < 1) revert IDeck.InvalidVariationIndex();
+        address recipient = variationMint.recipient;
+        if (variationMint.amount > MAX_UINT_32) revert IDeck.TooManyRequested();
+        uint32 amount = variationMint.amount;
+        if (claim.startingTokenId > MAX_UINT_80) revert IDeck.InvalidStartingTokenId();
+
+        tokenIds[j] = claim.startingTokenId + variationIndex - 1;
+        amounts[j] = amount;
+        receivers[j] = recipient;
+        totalMinted += variationMint.amount;
+        unchecked {
+          ++j;
+        }
+      }
+
+      claim.total += totalMinted;
+      IERC1155CreatorCore(mintData.creatorContractAddress).mintExtensionExisting(receivers, tokenIds, amounts);
+      unchecked {
+        ++i;
+      }
+    }
+  }
+
+  /**
+   * See {ICreatorExtensionTokenURI-tokenURI}.
+   */
+  function tokenURI(address creatorContractAddress, uint256 tokenId) external view override returns (string memory uri) {
+    uint256 instanceId = _tokenInstances[creatorContractAddress][tokenId];
+    if (instanceId == 0) revert IDeck.TokenDNE();
+    Claim memory claim = _getClaim(creatorContractAddress, instanceId);
+
+    string memory prefix = "";
+    if (claim.storageProtocol == StorageProtocol.ARWEAVE) {
+      prefix = ARWEAVE_PREFIX;
+    } else if (claim.storageProtocol == StorageProtocol.IPFS) {
+      prefix = IPFS_PREFIX;
+    }
+    uri = string(abi.encodePacked(prefix, claim.location, "/", Strings.toString(tokenId - claim.startingTokenId + 1)));
+  }
+
+  /**
+   * See {IERC1155Deck-updateTokenURIParams}.
+   */
+  function updateTokenURIParams(
+    address creatorContractAddress,
+    uint256 instanceId,
+    StorageProtocol storageProtocol,
+    string calldata location
+  ) external override creatorAdminRequired(creatorContractAddress) {
+    Claim storage claim = _getClaim(creatorContractAddress, instanceId);
+    if (storageProtocol == StorageProtocol.INVALID) revert IDeck.InvalidStorageProtocol();
+    claim.storageProtocol = storageProtocol;
+    claim.location = location;
+    emit DeckClaimUpdated(creatorContractAddress, instanceId);
+  }
+}

--- a/packages/manifold/contracts/deckClaims/IDeck.sol
+++ b/packages/manifold/contracts/deckClaims/IDeck.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/// @author: manifold.xyz
+
+/**
+ * Deck Lazy Claim interface
+ */
+interface IDeck {
+  enum StorageProtocol {
+    INVALID,
+    NONE,
+    ARWEAVE,
+    IPFS
+  }
+
+  error InvalidStorageProtocol();
+  error InvalidInstance();
+  error InvalidInput();
+  error InvalidSignature();
+  error InvalidVariationIndex();
+  error InvalidStartingTokenId();
+  error ClaimAlreadyInitialized();
+  error ClaimNotInitialized();
+  error ContractDeprecated();
+  error TokenDNE();
+  error FailedToTransfer();
+  error TooManyRequested();
+
+  event DeckClaimInitialized(address indexed creatorContract, uint256 indexed instanceId, address initializer);
+  event DeckClaimUpdated(address indexed creatorContract, uint256 indexed instanceId);
+
+  struct VariationMint {
+    uint8 variationIndex;
+    uint32 amount;
+    address recipient;
+  }
+
+  struct ClaimMint {
+    address creatorContractAddress;
+    uint256 instanceId;
+    VariationMint[] variationMints;
+  }
+
+  /**
+   * @notice                          Set the signing address
+   * @param signer                    the signer address
+   */
+  function setSigner(address signer) external;
+
+  /**
+   * @notice                          Withdraw funds
+   */
+  function withdraw(address payable receiver, uint256 amount) external;
+
+  /**
+   * @notice                          Deliver NFTs
+   * @param mints                     the mints to deliver with creatorcontractaddress, instanceId and variationMints
+   */
+  function deliverMints(ClaimMint[] calldata mints) external;
+}

--- a/packages/manifold/contracts/deckClaims/IERC1155Deck.sol
+++ b/packages/manifold/contracts/deckClaims/IERC1155Deck.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+/// @author: manifold.xyz
+
+import "./IDeck.sol";
+
+/**
+ * Deck Lazy Claim interface for ERC-1155
+ */
+interface IERC1155Deck is IDeck {
+  struct Claim {
+    StorageProtocol storageProtocol;
+    uint32 total;
+    uint80 startingTokenId;
+    uint8 tokenVariations;
+    string location;
+  }
+
+  struct ClaimParameters {
+    StorageProtocol storageProtocol;
+    uint8 tokenVariations;
+    string location;
+  }
+
+  struct UpdateClaimParameters {
+    StorageProtocol storageProtocol;
+    string location;
+  }
+
+  /**
+   * @notice initialize a new claim, emit initialize event
+   * @param creatorContractAddress    the creator contract the claim will mint tokens for
+   * @param instanceId                the claim instanceId for the creator contract
+   * @param claimParameters           the parameters which will affect the minting behavior of the claim
+   */
+  function initializeClaim(
+    address creatorContractAddress,
+    uint256 instanceId,
+    ClaimParameters calldata claimParameters
+  ) external payable;
+
+  /**
+   * @notice update an existing claim at instanceId
+   * @param creatorContractAddress    the creator contract corresponding to the claim
+   * @param instanceId                the claim instanceId for the creator contract
+   * @param updateClaimParameters     the updateable parameters that affect the minting behavior of the claim
+   */
+  function updateClaim(
+    address creatorContractAddress,
+    uint256 instanceId,
+    UpdateClaimParameters calldata updateClaimParameters
+  ) external;
+
+  /**
+   * @notice get a claim corresponding to a creator contract and instanceId
+   * @param creatorContractAddress    the address of the creator contract
+   * @param instanceId                the claim instanceId for the creator contract
+   * @return                          the claim object
+   */
+  function getClaim(address creatorContractAddress, uint256 instanceId) external view returns (Claim memory);
+
+  /**
+   * @notice get a claim corresponding to a token
+   * @param creatorContractAddress    the address of the creator contract
+   * @param tokenId                   the tokenId of the claim
+   * @return                          the claim instanceId and claim object
+   */
+  function getClaimForToken(address creatorContractAddress, uint256 tokenId) external view returns (uint256, Claim memory);
+
+  /**
+   * @notice update tokenURI for an existing token
+   * @param creatorContractAddress    the creator contract corresponding to the claim
+   * @param instanceId                the instanceId of the claim for the creator contract
+   * @param storageProtocol           the storage protocol for the metadata
+   * @param location                  the location of the metadata
+   */
+  function updateTokenURIParams(
+    address creatorContractAddress,
+    uint256 instanceId,
+    StorageProtocol storageProtocol,
+    string calldata location
+  ) external;
+}

--- a/packages/manifold/script/ERC1155Deck.s.sol
+++ b/packages/manifold/script/ERC1155Deck.s.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Script.sol";
+import "../contracts/deckClaims/ERC1155Deck.sol";
+
+/**
+    Pro tip for testing! The private key can be whatever. This is what I did to test.
+    1. Uncomment the lines below and follow the instructions there to change the code.
+    2. Run the script, like `forge script script/ERC1155Deck.s.sol:DeployERC1155Deck --rpc-url https://eth-sepolia.g.alchemy.com/v2/xxx --broadcast`
+    3. It will print out the address, but give you an out of eth error.
+    4. Now you have the address, use your real wallet and send it some sepolia eth.
+    5. Now, run the script again. It will deploy and transfer the contract to your wallet.
+    In the end, you just basically used a random pk in the moment to deploy. You never had
+    to expose your personal pk to your mac's environment variable or anything.
+ */
+contract DeployERC1155Deck is Script {
+    function run() external {
+        // address initialOwner = <your wallet address>; // uncomment this and put in your desired owner address
+        address initialOwner = vm.envAddress("INITIAL_OWNER"); // comment this out on sepolia
+
+        // uint pk = some combo of 6s and 9s;
+        // address addr = vm.addr(pk);
+        // console.log(addr);
+
+        require(initialOwner != address(0), "Initial owner address not set.  Please configure INITIAL_OWNER.");
+
+        // uint256 deployerPrivateKey = pk; // uncomment this when testing on goerli
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY"); // comment this out when testing on goerli
+        vm.startBroadcast(deployerPrivateKey);
+
+        //  forge script script/ERC1155Deck.s.sol:DeployERC1155Deck --optimizer-runs 1000 --rpc-url <YOUR_NODE> --broadcast
+        // forge verify-contract --compiler-version 0.8.17 --optimizer-runs 1000 --chain sepolia <DEPLOYED_ADDRESS>  contracts/deckClaims/ERC1155Deck.sol:ERC1155Deck --constructor-args $(cast abi-encode "constructor(address)" "${INITIAL_OWNER}") --watch
+        new ERC1155Deck{salt: 0x16091cc3cd908d7d973f650f59bd476ac79090f0358f87c50a7f5caee0835a84}(initialOwner);
+        vm.stopBroadcast();
+    }
+}

--- a/packages/manifold/test/deck/ERC1155Deck.t.sol
+++ b/packages/manifold/test/deck/ERC1155Deck.t.sol
@@ -1,0 +1,722 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import "../../contracts/deckClaims/IERC1155Deck.sol";
+import "../../contracts/deckClaims/ERC1155Deck.sol";
+import "../../contracts/deckClaims/IDeck.sol";
+import "../../contracts/deckClaims/Deck.sol";
+
+import "@manifoldxyz/creator-core-solidity/contracts/ERC1155Creator.sol";
+import "../mocks/Mock.sol";
+
+contract ERC1155DeckTest is Test {
+  ERC1155Deck public example;
+  ERC1155Creator public creatorCore1;
+  ERC1155Creator public creatorCore2;
+
+  address public creator = 0xc78Dc443c126af6E4f6Ed540c1e740C1b5be09cd;
+  address public owner = 0x6140F00e4Ff3936702E68744f2b5978885464cbB;
+  address public signingAddress = 0xc78dC443c126Af6E4f6eD540C1E740c1B5be09CE;
+  address public other = 0x5174cD462b60c536eb51D4ceC1D561D3Ea31004F;
+  address public other2 = 0x80AAC46bbd3C2FcE33681541a52CacBEd14bF425;
+
+  address public zeroAddress = address(0);
+
+  uint256 internal constant MAX_UINT_8 = 0xff;
+  uint256 internal constant MAX_UINT_56 = 0xffffffffffffff;
+
+  function setUp() public {
+    vm.startPrank(creator);
+    creatorCore1 = new ERC1155Creator("Token1", "NFT1");
+    creatorCore2 = new ERC1155Creator("Token2", "NFT2");
+    vm.stopPrank();
+
+    vm.startPrank(owner);
+    example = new ERC1155Deck(owner);
+    example.setSigner(address(signingAddress));
+    vm.stopPrank();
+
+    vm.startPrank(creator);
+    creatorCore1.registerExtension(address(example), "override");
+    creatorCore2.registerExtension(address(example), "override");
+    vm.stopPrank();
+
+    vm.deal(creator, 10 ether);
+    vm.deal(other, 10 ether);
+    vm.deal(other2, 10 ether);
+  }
+
+  function testAccess() public {
+    vm.startPrank(other);
+    // Must be admin
+    vm.expectRevert();
+    example.withdraw(payable(other), 20);
+    vm.expectRevert("AdminControl: Must be owner or admin");
+    example.setSigner(other);
+
+    IERC1155Deck.ClaimParameters memory claimP = IERC1155Deck.ClaimParameters({
+      storageProtocol: IDeck.StorageProtocol.IPFS,
+      tokenVariations: 5,
+      location: "ipfsHash1"
+    });
+    // Must be admin
+    vm.expectRevert();
+    example.initializeClaim(address(creatorCore1), 1, claimP);
+    // Succeeds because is admin
+    vm.stopPrank();
+    vm.startPrank(creator);
+    example.initializeClaim(address(creatorCore1), 1, claimP);
+    // Try as a different non admin
+    vm.stopPrank();
+    vm.startPrank(other2);
+    vm.expectRevert();
+    example.initializeClaim(address(creatorCore1), 2, claimP);
+
+    vm.stopPrank();
+  }
+
+  function testInitializeClaimSanitization() public {
+    vm.startPrank(creator);
+
+    IERC1155Deck.ClaimParameters memory claimP = IERC1155Deck.ClaimParameters({
+      storageProtocol: IDeck.StorageProtocol.INVALID,
+      tokenVariations: 5,
+      location: "arweaveHash1"
+    });
+
+    vm.expectRevert(IDeck.InvalidStorageProtocol.selector);
+    example.initializeClaim(address(creatorCore1), 1, claimP);
+
+    // Reset to valid storage protocol
+    claimP.storageProtocol = IDeck.StorageProtocol.ARWEAVE;
+
+    // Invalid instanceId = 0
+    vm.expectRevert(IDeck.InvalidInstance.selector);
+    example.initializeClaim(address(creatorCore1), 0, claimP);
+
+    // Invalid instanceId > MAX_UINT_56
+    vm.expectRevert(IDeck.InvalidInstance.selector);
+    example.initializeClaim(address(creatorCore1), MAX_UINT_56 + 1, claimP);
+
+    // Successful initialization
+    example.initializeClaim(address(creatorCore1), 1, claimP);
+
+    // Cannot reinitialize same instanceId
+    vm.expectRevert(IDeck.ClaimAlreadyInitialized.selector);
+    example.initializeClaim(address(creatorCore1), 1, claimP);
+
+    vm.stopPrank();
+  }
+
+  function testInitializeClaimWithDifferentProtocols() public {
+    vm.startPrank(creator);
+
+    // Test ARWEAVE protocol
+    IERC1155Deck.ClaimParameters memory claimP = IERC1155Deck.ClaimParameters({
+      storageProtocol: IDeck.StorageProtocol.ARWEAVE,
+      tokenVariations: 3,
+      location: "arweaveHash1"
+    });
+    example.initializeClaim(address(creatorCore1), 1, claimP);
+
+    IERC1155Deck.Claim memory claim = example.getClaim(address(creatorCore1), 1);
+    assertEq(uint(claim.storageProtocol), uint(IDeck.StorageProtocol.ARWEAVE));
+    assertEq(claim.location, "arweaveHash1");
+    assertEq(claim.tokenVariations, 3);
+    assertEq(claim.total, 0);
+    assertEq(claim.startingTokenId, 1);
+
+    // Test IPFS protocol
+    claimP.storageProtocol = IDeck.StorageProtocol.IPFS;
+    claimP.location = "ipfsHash1";
+    claimP.tokenVariations = 5;
+    example.initializeClaim(address(creatorCore1), 2, claimP);
+
+    claim = example.getClaim(address(creatorCore1), 2);
+    assertEq(uint(claim.storageProtocol), uint(IDeck.StorageProtocol.IPFS));
+    assertEq(claim.location, "ipfsHash1");
+    assertEq(claim.tokenVariations, 5);
+    assertEq(claim.total, 0);
+    assertEq(claim.startingTokenId, 4); // after first claim's 3 tokens
+
+    // Test NONE protocol
+    claimP.storageProtocol = IDeck.StorageProtocol.NONE;
+    claimP.location = "";
+    example.initializeClaim(address(creatorCore1), 3, claimP);
+
+    claim = example.getClaim(address(creatorCore1), 3);
+    assertEq(uint(claim.storageProtocol), uint(IDeck.StorageProtocol.NONE));
+
+    vm.stopPrank();
+  }
+
+  function test_InitializeClaimWithMaxVariations() public {
+    vm.startPrank(creator);
+
+    IERC1155Deck.ClaimParameters memory claimP = IERC1155Deck.ClaimParameters({
+      storageProtocol: IDeck.StorageProtocol.ARWEAVE,
+      tokenVariations: uint8(MAX_UINT_8),
+      location: "arweaveHash1"
+    });
+
+    example.initializeClaim(address(creatorCore1), 1, claimP);
+
+    IERC1155Deck.Claim memory claim = example.getClaim(address(creatorCore1), 1);
+    assertEq(claim.tokenVariations, uint8(MAX_UINT_8));
+
+    vm.stopPrank();
+  }
+
+  function test_UpdateClaim() public {
+    vm.startPrank(creator);
+
+    IERC1155Deck.ClaimParameters memory claimP = IERC1155Deck.ClaimParameters({
+      storageProtocol: IDeck.StorageProtocol.ARWEAVE,
+      tokenVariations: 5,
+      location: "arweaveHash1"
+    });
+    example.initializeClaim(address(creatorCore1), 1, claimP);
+
+    IERC1155Deck.UpdateClaimParameters memory claimU = IERC1155Deck.UpdateClaimParameters({
+      storageProtocol: IDeck.StorageProtocol.IPFS,
+      location: "ipfsHashUpdated"
+    });
+
+    example.updateClaim(address(creatorCore1), 1, claimU);
+
+    IERC1155Deck.Claim memory claim = example.getClaim(address(creatorCore1), 1);
+    assertEq(uint(claim.storageProtocol), uint(IDeck.StorageProtocol.IPFS));
+    assertEq(claim.location, "ipfsHashUpdated");
+    // tokenVariations should remain unchanged
+    assertEq(claim.tokenVariations, 5);
+
+    vm.stopPrank();
+  }
+
+  function test_UpdateClaimSanitization() public {
+    vm.startPrank(creator);
+
+    IERC1155Deck.ClaimParameters memory claimP = IERC1155Deck.ClaimParameters({
+      storageProtocol: IDeck.StorageProtocol.ARWEAVE,
+      tokenVariations: 5,
+      location: "arweaveHash1"
+    });
+    example.initializeClaim(address(creatorCore1), 1, claimP);
+
+    IERC1155Deck.UpdateClaimParameters memory claimU = IERC1155Deck.UpdateClaimParameters({
+      storageProtocol: IDeck.StorageProtocol.INVALID,
+      location: "newHash"
+    });
+
+    vm.expectRevert(IDeck.InvalidStorageProtocol.selector);
+    example.updateClaim(address(creatorCore1), 1, claimU);
+
+    // Cannot update non-existent claim
+    claimU.storageProtocol = IDeck.StorageProtocol.ARWEAVE;
+    vm.expectRevert(IDeck.ClaimNotInitialized.selector);
+    example.updateClaim(address(creatorCore1), 99, claimU);
+
+    // instanceId = 0 also fails with ClaimNotInitialized (checked before InvalidInstance in contract)
+    vm.expectRevert(IDeck.ClaimNotInitialized.selector);
+    example.updateClaim(address(creatorCore1), 0, claimU);
+
+    vm.stopPrank();
+  }
+
+  function test_RevertWhen_UpdateClaimNotClaimOwner() public {
+    vm.startPrank(creator);
+
+    IERC1155Deck.ClaimParameters memory claimP = IERC1155Deck.ClaimParameters({
+      storageProtocol: IDeck.StorageProtocol.IPFS,
+      tokenVariations: 5,
+      location: "ipfsHash1"
+    });
+    example.initializeClaim(address(creatorCore1), 1, claimP);
+    vm.stopPrank();
+
+    vm.startPrank(other);
+    IERC1155Deck.UpdateClaimParameters memory claimU = IERC1155Deck.UpdateClaimParameters({
+      storageProtocol: IDeck.StorageProtocol.ARWEAVE,
+      location: "newHash"
+    });
+    vm.expectRevert();
+    example.updateClaim(address(creatorCore1), 1, claimU);
+    vm.stopPrank();
+  }
+
+  function testInvalidSigner() public {
+    vm.startPrank(creator);
+
+    IERC1155Deck.ClaimParameters memory claimP = IERC1155Deck.ClaimParameters({
+      storageProtocol: IDeck.StorageProtocol.ARWEAVE,
+      tokenVariations: 5,
+      location: "arweaveHash1"
+    });
+    example.initializeClaim(address(creatorCore1), 1, claimP);
+    vm.stopPrank();
+
+    vm.startPrank(other);
+    IDeck.ClaimMint[] memory mints = new IDeck.ClaimMint[](1);
+    IDeck.VariationMint[] memory variationMints = new IDeck.VariationMint[](1);
+    variationMints[0] = IDeck.VariationMint({ variationIndex: 1, amount: 1, recipient: other });
+    mints[0] = IDeck.ClaimMint({
+      creatorContractAddress: address(creatorCore1),
+      instanceId: 1,
+      variationMints: variationMints
+    });
+
+    vm.expectRevert(IDeck.InvalidSignature.selector);
+    example.deliverMints(mints);
+    vm.stopPrank();
+  }
+
+  function testDeliverMints() public {
+    vm.startPrank(creator);
+
+    IERC1155Deck.ClaimParameters memory claimP = IERC1155Deck.ClaimParameters({
+      storageProtocol: IDeck.StorageProtocol.ARWEAVE,
+      tokenVariations: 5,
+      location: "arweaveHash1"
+    });
+    example.initializeClaim(address(creatorCore1), 1, claimP);
+    vm.stopPrank();
+
+    vm.startPrank(signingAddress);
+    IDeck.ClaimMint[] memory mints = new IDeck.ClaimMint[](1);
+    IDeck.VariationMint[] memory variationMints = new IDeck.VariationMint[](2);
+    variationMints[0] = IDeck.VariationMint({ variationIndex: 1, amount: 5, recipient: other });
+    variationMints[1] = IDeck.VariationMint({ variationIndex: 3, amount: 10, recipient: other2 });
+    mints[0] = IDeck.ClaimMint({
+      creatorContractAddress: address(creatorCore1),
+      instanceId: 1,
+      variationMints: variationMints
+    });
+
+    example.deliverMints(mints);
+
+    // Check balances
+    assertEq(creatorCore1.balanceOf(other, 1), 5);
+    assertEq(creatorCore1.balanceOf(other2, 3), 10);
+    vm.stopPrank();
+  }
+
+  function testDeliverMintsMultipleClaims() public {
+    vm.startPrank(creator);
+
+    IERC1155Deck.ClaimParameters memory claimP = IERC1155Deck.ClaimParameters({
+      storageProtocol: IDeck.StorageProtocol.ARWEAVE,
+      tokenVariations: 5,
+      location: "arweaveHash1"
+    });
+    example.initializeClaim(address(creatorCore1), 1, claimP);
+
+    claimP.location = "arweaveHash2";
+    claimP.tokenVariations = 3;
+    example.initializeClaim(address(creatorCore1), 2, claimP);
+    vm.stopPrank();
+
+    vm.startPrank(signingAddress);
+    IDeck.ClaimMint[] memory mints = new IDeck.ClaimMint[](2);
+
+    IDeck.VariationMint[] memory variationMints1 = new IDeck.VariationMint[](1);
+    variationMints1[0] = IDeck.VariationMint({ variationIndex: 1, amount: 2, recipient: other });
+    mints[0] = IDeck.ClaimMint({
+      creatorContractAddress: address(creatorCore1),
+      instanceId: 1,
+      variationMints: variationMints1
+    });
+
+    IDeck.VariationMint[] memory variationMints2 = new IDeck.VariationMint[](1);
+    variationMints2[0] = IDeck.VariationMint({ variationIndex: 2, amount: 3, recipient: other2 });
+    mints[1] = IDeck.ClaimMint({
+      creatorContractAddress: address(creatorCore1),
+      instanceId: 2,
+      variationMints: variationMints2
+    });
+
+    example.deliverMints(mints);
+
+    // Check balances - first claim starts at tokenId 1, second at tokenId 6
+    assertEq(creatorCore1.balanceOf(other, 1), 2);
+    assertEq(creatorCore1.balanceOf(other2, 7), 3); // tokenId 6 + variationIndex 2 - 1 = 7
+    vm.stopPrank();
+  }
+
+  function testDeliverMintsInvalidVariationIndex() public {
+    vm.startPrank(creator);
+
+    IERC1155Deck.ClaimParameters memory claimP = IERC1155Deck.ClaimParameters({
+      storageProtocol: IDeck.StorageProtocol.ARWEAVE,
+      tokenVariations: 5,
+      location: "arweaveHash1"
+    });
+    example.initializeClaim(address(creatorCore1), 1, claimP);
+    vm.stopPrank();
+
+    vm.startPrank(signingAddress);
+    IDeck.ClaimMint[] memory mints = new IDeck.ClaimMint[](1);
+    IDeck.VariationMint[] memory variationMints = new IDeck.VariationMint[](1);
+
+    // variationIndex 0 is invalid (must be >= 1)
+    variationMints[0] = IDeck.VariationMint({ variationIndex: 0, amount: 1, recipient: other });
+    mints[0] = IDeck.ClaimMint({
+      creatorContractAddress: address(creatorCore1),
+      instanceId: 1,
+      variationMints: variationMints
+    });
+
+    vm.expectRevert(IDeck.InvalidVariationIndex.selector);
+    example.deliverMints(mints);
+
+    // variationIndex 6 is invalid (tokenVariations is 5)
+    variationMints[0] = IDeck.VariationMint({ variationIndex: 6, amount: 1, recipient: other });
+    mints[0] = IDeck.ClaimMint({
+      creatorContractAddress: address(creatorCore1),
+      instanceId: 1,
+      variationMints: variationMints
+    });
+
+    vm.expectRevert(IDeck.InvalidVariationIndex.selector);
+    example.deliverMints(mints);
+
+    vm.stopPrank();
+  }
+
+  function testTokenURI() public {
+    vm.startPrank(creator);
+
+    IERC1155Deck.ClaimParameters memory claimP = IERC1155Deck.ClaimParameters({
+      storageProtocol: IDeck.StorageProtocol.ARWEAVE,
+      tokenVariations: 5,
+      location: "arweaveHash1"
+    });
+    example.initializeClaim(address(creatorCore1), 1, claimP);
+
+    // Check URIs for all variations
+    assertEq("https://arweave.net/arweaveHash1/1", creatorCore1.uri(1));
+    assertEq("https://arweave.net/arweaveHash1/2", creatorCore1.uri(2));
+    assertEq("https://arweave.net/arweaveHash1/3", creatorCore1.uri(3));
+    assertEq("https://arweave.net/arweaveHash1/4", creatorCore1.uri(4));
+    assertEq("https://arweave.net/arweaveHash1/5", creatorCore1.uri(5));
+
+    // Create second claim with different location
+    claimP.tokenVariations = 3;
+    claimP.location = "arweaveHash2";
+    example.initializeClaim(address(creatorCore1), 2, claimP);
+
+    // Second claim starts at tokenId 6
+    assertEq("https://arweave.net/arweaveHash2/1", creatorCore1.uri(6));
+    assertEq("https://arweave.net/arweaveHash2/2", creatorCore1.uri(7));
+    assertEq("https://arweave.net/arweaveHash2/3", creatorCore1.uri(8));
+
+    vm.stopPrank();
+  }
+
+  function testTokenURIWithIPFS() public {
+    vm.startPrank(creator);
+
+    IERC1155Deck.ClaimParameters memory claimP = IERC1155Deck.ClaimParameters({
+      storageProtocol: IDeck.StorageProtocol.IPFS,
+      tokenVariations: 3,
+      location: "QmTestHash"
+    });
+    example.initializeClaim(address(creatorCore1), 1, claimP);
+
+    assertEq("ipfs://QmTestHash/1", creatorCore1.uri(1));
+    assertEq("ipfs://QmTestHash/2", creatorCore1.uri(2));
+    assertEq("ipfs://QmTestHash/3", creatorCore1.uri(3));
+
+    vm.stopPrank();
+  }
+
+  function testTokenURIWithNone() public {
+    vm.startPrank(creator);
+
+    IERC1155Deck.ClaimParameters memory claimP = IERC1155Deck.ClaimParameters({
+      storageProtocol: IDeck.StorageProtocol.NONE,
+      tokenVariations: 2,
+      location: "customLocation"
+    });
+    example.initializeClaim(address(creatorCore1), 1, claimP);
+
+    // NONE storage protocol should have no prefix
+    assertEq("customLocation/1", creatorCore1.uri(1));
+    assertEq("customLocation/2", creatorCore1.uri(2));
+
+    vm.stopPrank();
+  }
+
+  function testUpdateTokenURI() public {
+    vm.startPrank(creator);
+
+    IERC1155Deck.ClaimParameters memory claimP = IERC1155Deck.ClaimParameters({
+      storageProtocol: IDeck.StorageProtocol.ARWEAVE,
+      tokenVariations: 5,
+      location: "arweaveHash1"
+    });
+    example.initializeClaim(address(creatorCore1), 1, claimP);
+
+    // Original URIs
+    assertEq("https://arweave.net/arweaveHash1/1", creatorCore1.uri(1));
+    assertEq("https://arweave.net/arweaveHash1/2", creatorCore1.uri(2));
+
+    // Update token URI
+    example.updateTokenURIParams(address(creatorCore1), 1, IDeck.StorageProtocol.ARWEAVE, "arweaveHashNEW");
+
+    assertEq("https://arweave.net/arweaveHashNEW/1", creatorCore1.uri(1));
+    assertEq("https://arweave.net/arweaveHashNEW/2", creatorCore1.uri(2));
+
+    // Update to different storage protocol
+    example.updateTokenURIParams(address(creatorCore1), 1, IDeck.StorageProtocol.IPFS, "QmNewHash");
+
+    assertEq("ipfs://QmNewHash/1", creatorCore1.uri(1));
+    assertEq("ipfs://QmNewHash/2", creatorCore1.uri(2));
+
+    vm.stopPrank();
+  }
+
+  function test_RevertWhen_UpdateTokenURIInvalidProtocol() public {
+    vm.startPrank(creator);
+
+    IERC1155Deck.ClaimParameters memory claimP = IERC1155Deck.ClaimParameters({
+      storageProtocol: IDeck.StorageProtocol.ARWEAVE,
+      tokenVariations: 5,
+      location: "arweaveHash1"
+    });
+    example.initializeClaim(address(creatorCore1), 1, claimP);
+
+    vm.expectRevert(IDeck.InvalidStorageProtocol.selector);
+    example.updateTokenURIParams(address(creatorCore1), 1, IDeck.StorageProtocol.INVALID, "newHash");
+
+    vm.stopPrank();
+  }
+
+  function test_RevertWhen_UpdateTokenURINotAdmin() public {
+    vm.startPrank(creator);
+
+    IERC1155Deck.ClaimParameters memory claimP = IERC1155Deck.ClaimParameters({
+      storageProtocol: IDeck.StorageProtocol.ARWEAVE,
+      tokenVariations: 5,
+      location: "arweaveHash1"
+    });
+    example.initializeClaim(address(creatorCore1), 1, claimP);
+    vm.stopPrank();
+
+    vm.startPrank(other);
+    vm.expectRevert();
+    example.updateTokenURIParams(address(creatorCore1), 1, IDeck.StorageProtocol.IPFS, "newHash");
+    vm.stopPrank();
+  }
+
+  function testGetClaimForToken() public {
+    vm.startPrank(creator);
+
+    IERC1155Deck.ClaimParameters memory claimP = IERC1155Deck.ClaimParameters({
+      storageProtocol: IDeck.StorageProtocol.ARWEAVE,
+      tokenVariations: 3,
+      location: "arweaveHash1"
+    });
+    example.initializeClaim(address(creatorCore1), 1, claimP);
+
+    claimP.location = "arweaveHash2";
+    claimP.tokenVariations = 2;
+    example.initializeClaim(address(creatorCore1), 2, claimP);
+
+    // Get claim for tokens from first claim
+    (uint256 instanceId1, IERC1155Deck.Claim memory claim1) = example.getClaimForToken(address(creatorCore1), 1);
+    assertEq(instanceId1, 1);
+    assertEq(claim1.location, "arweaveHash1");
+
+    (uint256 instanceId2, IERC1155Deck.Claim memory claim2) = example.getClaimForToken(address(creatorCore1), 3);
+    assertEq(instanceId2, 1);
+    assertEq(claim2.location, "arweaveHash1");
+
+    // Get claim for tokens from second claim
+    (uint256 instanceId3, IERC1155Deck.Claim memory claim3) = example.getClaimForToken(address(creatorCore1), 4);
+    assertEq(instanceId3, 2);
+    assertEq(claim3.location, "arweaveHash2");
+
+    vm.stopPrank();
+  }
+
+  function test_RevertWhen_InitializeClaimOnDeprecated() public {
+    vm.startPrank(owner);
+    example.deprecate(true);
+    vm.stopPrank();
+
+    vm.startPrank(creator);
+    IERC1155Deck.ClaimParameters memory claimP = IERC1155Deck.ClaimParameters({
+      storageProtocol: IDeck.StorageProtocol.IPFS,
+      tokenVariations: 5,
+      location: "ipfsHash1"
+    });
+    vm.expectRevert(IDeck.ContractDeprecated.selector);
+    example.initializeClaim(address(creatorCore1), 1, claimP);
+    vm.stopPrank();
+
+    vm.startPrank(owner);
+    example.deprecate(false);
+    vm.stopPrank();
+
+    vm.startPrank(creator);
+    // Can initialize claim after deprecation removal
+    example.initializeClaim(address(creatorCore1), 1, claimP);
+    vm.stopPrank();
+  }
+
+  function test_RevertWhen_UpdateClaimOnDeprecated() public {
+    vm.startPrank(creator);
+    IERC1155Deck.ClaimParameters memory claimP = IERC1155Deck.ClaimParameters({
+      storageProtocol: IDeck.StorageProtocol.ARWEAVE,
+      tokenVariations: 5,
+      location: "arweaveHash1"
+    });
+    example.initializeClaim(address(creatorCore1), 1, claimP);
+    vm.stopPrank();
+
+    vm.startPrank(owner);
+    example.deprecate(true);
+    vm.stopPrank();
+
+    vm.startPrank(creator);
+    IERC1155Deck.UpdateClaimParameters memory claimU = IERC1155Deck.UpdateClaimParameters({
+      storageProtocol: IDeck.StorageProtocol.ARWEAVE,
+      location: "newHash"
+    });
+    vm.expectRevert(IDeck.ContractDeprecated.selector);
+    example.updateClaim(address(creatorCore1), 1, claimU);
+    vm.stopPrank();
+
+    vm.startPrank(owner);
+    example.deprecate(false);
+    vm.stopPrank();
+
+    vm.startPrank(creator);
+    // Can update claim after deprecation removal
+    example.updateClaim(address(creatorCore1), 1, claimU);
+    vm.stopPrank();
+  }
+
+  function test_Deprecate() public {
+    assertEq(example.deprecated(), false);
+
+    vm.startPrank(owner);
+    example.deprecate(true);
+    assertEq(example.deprecated(), true);
+    example.deprecate(false);
+    assertEq(example.deprecated(), false);
+    vm.stopPrank();
+
+    // Cannot call deprecate if not an admin
+    vm.startPrank(other);
+    vm.expectRevert(bytes("AdminControl: Must be owner or admin"));
+    example.deprecate(true);
+    vm.stopPrank();
+
+    vm.startPrank(owner);
+    example.approveAdmin(other);
+    vm.stopPrank();
+
+    vm.startPrank(other);
+    example.deprecate(true);
+    assertEq(example.deprecated(), true);
+    vm.stopPrank();
+
+    vm.startPrank(owner);
+    example.revokeAdmin(other);
+    vm.stopPrank();
+
+    vm.startPrank(other);
+    vm.expectRevert(bytes("AdminControl: Must be owner or admin"));
+    example.deprecate(false);
+    assertEq(example.deprecated(), true);
+    vm.stopPrank();
+  }
+
+  function testWithdraw() public {
+    // Send some ETH to the contract
+    vm.deal(address(example), 1 ether);
+
+    uint256 ownerBalanceBefore = owner.balance;
+
+    vm.startPrank(owner);
+    example.withdraw(payable(owner), 0.5 ether);
+    vm.stopPrank();
+
+    assertEq(owner.balance, ownerBalanceBefore + 0.5 ether);
+    assertEq(address(example).balance, 0.5 ether);
+  }
+
+  function testSupportsInterface() public {
+    // IERC1155Deck
+    assertTrue(example.supportsInterface(type(IERC1155Deck).interfaceId));
+    // IDeck
+    assertTrue(example.supportsInterface(type(IDeck).interfaceId));
+    // ICreatorExtensionTokenURI
+    assertTrue(example.supportsInterface(type(ICreatorExtensionTokenURI).interfaceId));
+    // IERC165
+    assertTrue(example.supportsInterface(type(IERC165).interfaceId));
+  }
+
+  function testSetSigner() public {
+    vm.startPrank(owner);
+    example.setSigner(other);
+    vm.stopPrank();
+
+    // Now other should be the signer
+    vm.startPrank(creator);
+    IERC1155Deck.ClaimParameters memory claimP = IERC1155Deck.ClaimParameters({
+      storageProtocol: IDeck.StorageProtocol.ARWEAVE,
+      tokenVariations: 5,
+      location: "arweaveHash1"
+    });
+    example.initializeClaim(address(creatorCore1), 1, claimP);
+    vm.stopPrank();
+
+    // Old signer should fail
+    vm.startPrank(signingAddress);
+    IDeck.ClaimMint[] memory mints = new IDeck.ClaimMint[](1);
+    IDeck.VariationMint[] memory variationMints = new IDeck.VariationMint[](1);
+    variationMints[0] = IDeck.VariationMint({ variationIndex: 1, amount: 1, recipient: other });
+    mints[0] = IDeck.ClaimMint({
+      creatorContractAddress: address(creatorCore1),
+      instanceId: 1,
+      variationMints: variationMints
+    });
+
+    vm.expectRevert(IDeck.InvalidSignature.selector);
+    example.deliverMints(mints);
+    vm.stopPrank();
+
+    // New signer should succeed
+    vm.startPrank(other);
+    example.deliverMints(mints);
+    assertEq(creatorCore1.balanceOf(other, 1), 1);
+    vm.stopPrank();
+  }
+
+  function testMultipleCreatorContracts() public {
+    vm.startPrank(creator);
+
+    IERC1155Deck.ClaimParameters memory claimP = IERC1155Deck.ClaimParameters({
+      storageProtocol: IDeck.StorageProtocol.ARWEAVE,
+      tokenVariations: 3,
+      location: "hash1"
+    });
+
+    // Initialize on both creator contracts with same instanceId
+    example.initializeClaim(address(creatorCore1), 1, claimP);
+    claimP.location = "hash2";
+    example.initializeClaim(address(creatorCore2), 1, claimP);
+
+    // Each should have their own claims
+    IERC1155Deck.Claim memory claim1 = example.getClaim(address(creatorCore1), 1);
+    IERC1155Deck.Claim memory claim2 = example.getClaim(address(creatorCore2), 1);
+
+    assertEq(claim1.location, "hash1");
+    assertEq(claim2.location, "hash2");
+
+    vm.stopPrank();
+  }
+}


### PR DESCRIPTION
## Objective

Add a new Deck claim extension that enables creators to initialize claims with multiple token variations (card deck-style distribution), where a designated signer can deliver mints to specified recipients.

## Summary of Changes

- **New contracts:**
  - `contracts/deckClaims/IDeck.sol` - Base interface with shared types (StorageProtocol enum, ClaimMint struct, VariationMint struct) and error definitions
  - `contracts/deckClaims/Deck.sol` - Abstract base contract with admin controls, signer validation, and withdraw functionality
  - `contracts/deckClaims/IERC1155Deck.sol` - ERC1155-specific interface extending IDeck
  - `contracts/deckClaims/ERC1155Deck.sol` - Full implementation with claim initialization, token URI handling, and batch mint delivery

- **Test coverage:**
  - `test/deck/ERC1155Deck.t.sol` - Comprehensive Foundry tests (25 test cases) covering access control, claim initialization, mint delivery, token URI generation, and edge cases

- **Documentation:**
  - `CLAUDE.md` - AI assistant guidelines for the project

## Key Flows

1. **Claim Initialization**: Creator admin calls `initializeClaim()` with storage protocol, token variations count, and metadata location. This mints the initial token variations to the caller.

2. **Mint Delivery**: Designated signer calls `deliverMints()` with array of ClaimMint structs specifying recipients, variation indices, and amounts. Tokens are minted to recipients via `mintExtensionExisting()`.

3. **Token URI Resolution**: URIs are constructed from storage protocol prefix (ARWEAVE/IPFS/NONE) + location + variation index.

## Test Plan

- [x] All 25 Foundry tests pass
- [x] Access control tests (admin-only functions)
- [x] Claim initialization with different storage protocols
- [x] Mint delivery with valid/invalid variation indices
- [x] Multiple claims per creator contract
- [x] Multiple creator contracts
- [x] Token URI generation for ARWEAVE/IPFS/NONE protocols
- [x] Deprecation functionality
- [x] Withdraw functionality
- [x] Signer management

🤖 Generated with [Claude Code](https://claude.com/claude-code)