### PR TITLE
docs: add LLM wiki for creator-core-extensions

### DIFF
--- a/docs/llm-wiki/README.md
+++ b/docs/llm-wiki/README.md
@@ -1,0 +1,26 @@
+# LLM Wiki — creator-core-extensions-solidity
+
+An interlinked, source-grounded knowledge base for this repo, built for both humans and AI agents to quickly understand the contract families without re-reading ~90 `.sol` files.
+
+Every claim (function signatures, struct fields, events, errors) is traced to a real source file at the commit this wiki was generated against. Pages cross-reference source with inline paths relative to `packages/` (e.g. `manifold/contracts/lazyclaim/LazyPayableClaim.sol`) and link each other with `[[wikilinks]]` — open the directory in Obsidian or VS Code for clickable navigation.
+
+## Where to start
+
+- **[index.md](./index.md)** — the catalog. Every page with a one-line "the thing to know."
+- **[concepts/repo-overview.md](./concepts/repo-overview.md)** — architecture, package map, and the shared singleton extension model. Read this first.
+- **[concepts/shared-libraries.md](./concepts/shared-libraries.md)** — the cross-cutting plumbing (membership fee gate, delegation registry, standard mint events).
+- **[SCHEMA.md](./SCHEMA.md)** — conventions, tag taxonomy, and the rules the wiki follows.
+
+## Structure
+
+```
+docs/llm-wiki/
+├── SCHEMA.md        # conventions + domain config
+├── index.md         # sectioned catalog with one-line summaries
+├── log.md           # chronological build/maintenance log
+└── concepts/        # one page per contract family (19 pages)
+```
+
+## Maintaining it
+
+When contracts change, update the relevant `concepts/*.md` page, bump its `updated` frontmatter date, adjust its `index.md` entry, and append to `log.md`. Keep every claim traced to source — cite the file or leave it out. See `SCHEMA.md` for the full contribution rules.

--- a/docs/llm-wiki/SCHEMA.md
+++ b/docs/llm-wiki/SCHEMA.md
@@ -1,0 +1,82 @@
+# Wiki Schema — creator-core-extensions-solidity Knowledge Base
+
+## Domain
+
+A code-oriented knowledge base for **[manifoldxyz/creator-core-extensions-solidity](https://github.com/manifoldxyz/creator-core-extensions-solidity)** — a monorepo of Solidity *extension applications ("Apps")* that install onto any [Manifold Creator Core](https://github.com/manifoldxyz/creator-core-solidity) ERC-721/ERC-1155 contract to add claims, burn-redeems, editions, metadata, and more.
+
+Purpose: let an agent (or engineer) understand what each contract family does, its exact on-chain surface (functions/structs/events/errors traced to source), how the families relate, and the traps — without re-reading 90 `.sol` files each time.
+
+Pinned to commit `5bc29bd` (2026-03-20). Solidity `^0.8.17`, Foundry-primary (Truffle legacy tests).
+
+### The mental model (the #1 thing to get right)
+
+These are **shared, singleton extensions**: ONE instance of e.g. `ERC721LazyPayableClaim` is deployed per chain, and *every* creator contract installs that same instance and registers its own **instance** (a claim/burnRedeem/etc. keyed by `(creatorContractAddress, instanceId)`). The extension holds the logic + funds flow; the creator contract holds the tokens and delegates mint/burn to the registered extension. Contrast with a per-creator deployed contract — that is NOT how this repo works.
+
+Core inherited plumbing (from `@manifoldxyz/creator-core-solidity` + `libraries-solidity`):
+- `AdminControl` — owner/admin gating; `creatorAdminRequired(creator)` modifier restricts config to the creator's admins.
+- `IERC165` / `ICreatorExtensionTokenURI` — extensions advertise interfaces; creator core routes `tokenURI` to the extension.
+- Delegation Registry (v1 `IDelegationRegistry`, v2 `IDelegationRegistryV2`) — lets a delegate wallet mint/act on behalf of a vault.
+- `IManifoldMembership` — membership holders skip/discount the Manifold mint fee.
+
+## Conventions
+
+- File names: lowercase, hyphens, no spaces (e.g. `lazy-payable-claim.md`).
+- Every page has YAML frontmatter (see below).
+- Use `[[wikilinks]]` between pages (min 2 outbound per page).
+- Cross-reference source with inline code paths RELATIVE to `packages/`, e.g. `manifold/contracts/lazyclaim/LazyPayableClaim.sol` — NOT wikilinks. Line-anchor when useful: `...LazyPayableClaim.sol:L120`.
+- Every function signature / struct / error / event stated MUST trace to a real source file. Cite the path or omit it. NEVER invent a signature.
+- `updated` bumps on every edit. New pages get added to `index.md`. Every action appends to `log.md`.
+
+## Frontmatter
+
+```yaml
+---
+title: Page Title
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+type: concept | reference | comparison | query | overview
+package: manifold | dynamic | edition | enumerable | lazywhitelist | redeem | fonts | repo
+tags: [from taxonomy below]
+sources: [manifold/contracts/lazyclaim/LazyPayableClaim.sol]
+confidence: high | medium | low   # high ONLY when verified against source this run
+contested: true                    # unresolved contradiction; never silently overwrite
+---
+```
+
+`confidence: high` is reserved for claims read off the actual `.sol` during the run that set them.
+
+## Tag Taxonomy (add here BEFORE using)
+
+- Packages: `manifold`, `dynamic`, `edition`, `enumerable`, `lazywhitelist`, `redeem`, `fonts`
+- Surface: `contract`, `abstract`, `interface`, `library`, `struct`, `event`, `error`, `modifier`
+- Token standard: `erc721`, `erc1155`, `erc20`, `usdc`
+- Mechanic: `claim`, `burn-redeem`, `edition`, `single`, `metadata`, `soulbound`, `gacha`, `deck`, `frame`, `physical`, `cross-chain`, `collectible`, `operator-filter`, `whitelist`, `dynamic-token`, `enumerable`
+- Cross-cutting: `merkle`, `signature`, `delegation`, `membership`, `fee`, `admin`, `version-v2`
+- Meta: `overview`, `pitfall`, `comparison`, `gap`, `unknown`
+
+Every tag on a page must appear here. New tag → add here first.
+
+## Page types
+
+- `overview` (repo root) — architecture, package map, the shared extension model, install lifecycle. Start here.
+- `concept/` — one page per contract FAMILY (lazy-payable-claim, burn-redeem, deck-claims, ...). Each: what it is → contract map (files + roles) → key structs/params → external surface (the functions a caller uses, signatures traced) → fees/membership handling → pitfalls → open questions. Split at ~200 lines.
+- `reference/` — pure 1:1 surface dumps when a concept page would blow past 200 lines.
+- `comparisons/` — v1-vs-v2, ERC721-vs-ERC1155, redeem-package-vs-burnredeem, etc.
+- `queries/` — filed answers to "how do I X" worth keeping.
+
+## Page Thresholds
+
+- **Create a concept page** per contract family (a coherent directory under a package's `contracts/`), or per shared library group.
+- **Add to existing** when a source belongs to a family already covered.
+- **DON'T** create a page per interface `.sol` — fold interfaces into their family page.
+- **Split** when a page exceeds ~200 lines → dedicated `reference/` dump.
+
+## Confidence + contradiction policy
+
+1. Newer source (higher V-suffix, later commit) supersedes older; note both.
+2. Genuine contradiction → keep both, set `contested: true`, surface in run summary. NEVER silently overwrite.
+3. A vague claim you couldn't trace to source → flag as `unknown` in that page's open questions.
+
+## Honesty rule
+
+Every "this contract does X" claim traces to a source path, or it is marked `(inference)` and gets `confidence: low`. The wiki documents the code as written, not as assumed. Match-existing-behavior: describe what the contract does, don't editorialize about bugs unless the code proves one.

--- a/docs/llm-wiki/concepts/burn-redeem.md
+++ b/docs/llm-wiki/concepts/burn-redeem.md
@@ -1,0 +1,84 @@
+---
+title: Burn Redeem (v1 + V2 updatable-fee)
+created: 2026-07-15
+updated: 2026-07-15
+type: concept
+package: manifold
+tags: [contract, abstract, interface, library, burn-redeem, erc721, erc1155, merkle, membership, fee, version-v2, struct, pitfall]
+sources: [manifold/contracts/burnredeem/BurnRedeemCore.sol, manifold/contracts/burnredeem/BurnRedeemLib.sol, manifold/contracts/burnredeem/IBurnRedeemCore.sol, manifold/contracts/burnredeem/ERC721BurnRedeem.sol, manifold/contracts/burnredeem/ERC1155BurnRedeem.sol, manifold/contracts/burnredeem/Interfaces.sol, manifold/contracts/burnredeemUpdatableFee/BurnRedeemCoreV2.sol, manifold/contracts/burnredeemUpdatableFee/IBurnRedeemCoreV2.sol]
+confidence: high
+---
+
+# Burn Redeem (v1 + V2 updatable-fee)
+
+A **shared singleton** extension: one deployed contract that any Manifold creator installs. A burn-redeem instance is keyed by `(creatorContractAddress, instanceId)` in `mapping(address => mapping(uint256 => BurnRedeem)) _burnRedeems`. Holders **burn N input tokens** matching a configured burn-set to **mint a redeem output** on the creator contract. See [[repo-overview]] and the primitives in [[shared-libraries]]. Compare with [[lazy-payable-claim]] (mint-by-allowlist, no burn) and the older, separate [[redeem-package]] implementation.
+
+## Contract map
+
+| File | Role |
+|---|---|
+| `burnredeem/BurnRedeemCore.sol` | Abstract base: burn/receive/fee logic, storage, receivers ^[manifold/contracts/burnredeem/BurnRedeemCore.sol] |
+| `burnredeem/BurnRedeemLib.sol` | Library: init/update, param validation, `validateBurnItem`, events ^[manifold/contracts/burnredeem/BurnRedeemLib.sol] |
+| `burnredeem/ERC721BurnRedeem.sol` | Concrete: mints ERC721 redeem tokens (`mintExtension`) ^[manifold/contracts/burnredeem/ERC721BurnRedeem.sol] |
+| `burnredeem/ERC1155BurnRedeem.sol` | Concrete: mints one shared ERC1155 redeem token id ^[manifold/contracts/burnredeem/ERC1155BurnRedeem.sol] |
+| `burnredeem/IBurnRedeemCore.sol` | Structs, enums, errors, external surface |
+| `burnredeem/Interfaces.sol` | `Burnable721`, `OZBurnable1155`, `Manifold1155` burn shims |
+| `burnredeemUpdatableFee/*V2.sol` | V2 fork — mutable fees + global `active` flag (see delta) |
+
+Base inherits `ERC165, AdminControl, ReentrancyGuard, IBurnRedeemCore, ICreatorExtensionTokenURI`. Config is admin-gated: `_validateAdmin` requires `IAdminControl(creator).isAdmin(msg.sender)` — the caller must be admin on the **creator** contract, not this extension. ^[manifold/contracts/burnredeem/BurnRedeemCore.sol#L101]
+
+## Key structs (from `IBurnRedeemCore.sol`)
+
+- **`BurnItem`** — what is burnable: `ValidationType validationType; address contractAddress; TokenSpec tokenSpec; BurnSpec burnSpec; uint72 amount; uint256 minTokenId; uint256 maxTokenId; bytes32 merkleRoot`. ^[manifold/contracts/burnredeem/IBurnRedeemCore.sol#L59]
+  - `ValidationType { INVALID, CONTRACT, RANGE, MERKLE_TREE, ANY }` — allowlist by whole contract, by id-range, by merkle tree of ids, or ANY token from anywhere.
+  - `TokenSpec { INVALID, ERC721, ERC1155 }`; `BurnSpec { NONE, MANIFOLD, OPENZEPPELIN }` selects how the burn is performed.
+- **`BurnGroup`** — `uint256 requiredCount; BurnItem[] items`. Each group is an "M-of-N" requirement: `requiredCount` items from `items` must be supplied.
+- **`BurnRedeem`** (stored) — `paymentReceiver, storageProtocol, redeemedCount, redeemAmount, totalSupply, contractVersion, startDate, endDate, cost, location, burnSet`. `burnSet` is a `BurnGroup[]`; **every group** must be satisfied per redeem. ^[manifold/contracts/burnredeem/IBurnRedeemCore.sol#L105]
+- **`BurnToken`** (call input) — pointer into the config: `uint48 groupIndex; uint48 itemIndex; address contractAddress; uint256 id; bytes32[] merkleProof`. The caller pre-resolves which `BurnItem` each burned token satisfies.
+
+`storageProtocol == INVALID` is the "does-not-exist" sentinel — `_getBurnRedeem` reverts `BurnRedeemDoesNotExist` on it, and init refuses to overwrite a non-INVALID slot. ^[manifold/contracts/burnredeem/BurnRedeemLib.sol#L77]
+
+## External surface
+
+- `initializeBurnRedeem(creator, instanceId, params, identicalTokenURI)` (721) / `(creator, instanceId, params)` (1155). 721 caps `instanceId` at `MAX_UINT_56`; 1155 mints a placeholder token id (amount 0) at init to reserve the redeem id. ^[manifold/contracts/burnredeem/ERC1155BurnRedeem.sol#L41]
+- `updateBurnRedeem(...)`, `updateTokenURI/updateURI(...)`.
+- `burnRedeem(creator, instanceId, burnRedeemCount, BurnToken[])` `payable` — main entry. Batch overload takes parallel arrays; `burnRedeemWithData(..., bytes data)` adds event data. ^[manifold/contracts/burnredeem/BurnRedeemCore.sol#L160]
+- `airdrop(creator, instanceId, recipients[], amounts[])` — admin mints without burning.
+- `recoverERC721`, `withdraw`, `setMembershipAddress` (all `adminRequired`).
+
+`_burnRedeem` clamps count to available supply (`_getAvailableBurnRedeemCount`), computes fee, forwards `cost` to `paymentReceiver`, then `_burnTokens` then `_redeem`. Overpayment is refunded to the caller. ^[manifold/contracts/burnredeem/BurnRedeemCore.sol#L227]
+
+## How tokens are received & validated
+
+Two paths converge on `BurnRedeemLib.validateBurnItem` (checks contract match, RANGE bounds, or `MerkleProof.verify(keccak256(abi.encodePacked(tokenId)))`; `ANY` short-circuits): ^[manifold/contracts/burnredeem/BurnRedeemLib.sol#L131]
+
+1. **Approve-then-call**: `burnRedeem(...)` iterates `burnTokens`, validates each against `burnSet[groupIndex].items[itemIndex]`, burns, and tallies per-group counts — reverting `InvalidBurnAmount` unless every `groupCounts[i] == requiredCount * burnRedeemCount`. ^[manifold/contracts/burnredeem/BurnRedeemCore.sol#L485]
+2. **Safe-transfer callback**: `onERC721Received` / `onERC1155Received` / `onERC1155BatchReceived` decode target `(creator, instanceId, ...)` from `data` (`abi.decode`, requires `data.length % 32 == 0`). This "send-in" path is **restricted**: it only works when `cost == 0`, the burnSet is a single group with `requiredCount == 1`, and the sender is an active member (`_validateReceivedInput`) — because a bare transfer carries no ETH for fee/cost. ^[manifold/contracts/burnredeem/BurnRedeemCore.sol#L466]
+
+`_burn` dispatches on `burnSpec`: `NONE` → `safeTransferFrom` to `0xdEaD`; `MANIFOLD` → `Manifold1155.burn` / `Burnable721.burn`; `OPENZEPPELIN` → OZ `burn`. For 721 with a burn function it verifies `ownerOf == from` first (721 `burn` has no `from`). ^[manifold/contracts/burnredeem/BurnRedeemCore.sol#L545]
+
+## Fee & membership handling
+
+Two flat platform fees on top of the creator's `cost`: `BURN_FEE = 0.00069 ETH`, `MULTI_BURN_FEE = 0.00099 ETH` (applied when `burnTokens.length > 1`). Fees are **waived for active Manifold members** — `_isActiveMember` calls `IManifoldMembership.isActiveMember(sender)` on `manifoldMembershipContract` (see [[shared-libraries]]). `cost` goes to the instance `paymentReceiver`; accumulated fees stay in the contract for admin `withdraw`. ^[manifold/contracts/burnredeem/BurnRedeemCore.sol#L67]
+
+## v1 vs V2 delta (`burnredeemUpdatableFee/`)
+
+V2 is a near-verbatim fork of v1 with two additions: ^[manifold/contracts/burnredeemUpdatableFee/BurnRedeemCoreV2.sol#L67]
+
+1. **Updatable fees** — `BURN_FEE` / `MULTI_BURN_FEE` become **mutable public state** (not `constant`), set via `setBurnFees(uint256 burnFee, uint256 multiBurnFee)` (`adminRequired`). Everything about how the fee is charged is otherwise identical. ^[manifold/contracts/burnredeemUpdatableFee/BurnRedeemCoreV2.sol#L285]
+2. **Global kill switch** — new `bool public active = true` + `setActive(bool)`; `_initialize` reverts `Inactive()` when `!active` (blocks *new* instances only; existing burns keep working). New error `Inactive()` in `IBurnRedeemCoreV2`. ^[manifold/contracts/burnredeemUpdatableFee/BurnRedeemCoreV2.sol#L117]
+
+Struct/enum/receiver/validation logic is unchanged between versions.
+
+## Pitfalls
+
+- **V2 fees default to 0.** The V2 constructor does not set `BURN_FEE`/`MULTI_BURN_FEE`; until an admin calls `setBurnFees`, both are `0` and the platform collects nothing. ^[manifold/contracts/burnredeemUpdatableFee/BurnRedeemCoreV2.sol#L85]
+- **Send-in path is member-only + free-only.** Transferring an NFT directly (marketplace "burn" flows) silently fails via `InvalidInput` unless cost is 0, single-item single-group, and the sender is an active member.
+- **`admin` means creator-contract admin.** `_validateAdmin` checks the creator, not this extension — installing without admin rights blocks initialization.
+- **`totalSupply % redeemAmount` and `redeemedCount % redeemAmount` must be 0** on update, else `InvalidRedeemAmount`. ^[manifold/contracts/burnredeem/BurnRedeemLib.sol#L105]
+- **`BurnItem` amount rule**: ERC1155 must have `amount > 0`, ERC721 must have `amount == 0`, or `_setBurnGroups` reverts. ^[manifold/contracts/burnredeem/BurnRedeemLib.sol#L203]
+
+## Open questions
+
+- How does the 721 `contractVersion >= 3` tokenData packing (`uint56(instanceId) << 24 | count`) interact with pre-v3 creator cores that fall back to the `_redeemTokens` map? ^[manifold/contracts/burnredeem/ERC721BurnRedeem.sol#L95]
+- Is `MULTI_BURN_FEE` keyed on `burnTokens.length` alone (not `burnRedeemCount`)? Yes per source — worth confirming intended UX.

--- a/docs/llm-wiki/concepts/collectible.md
+++ b/docs/llm-wiki/concepts/collectible.md
@@ -1,0 +1,89 @@
+---
+title: Collectible
+created: 2026-07-15
+updated: 2026-07-15
+type: concept
+package: manifold
+tags: [contract, abstract, interface, collectible, erc721, signature, membership, fee, struct, pitfall]
+sources: [manifold/contracts/collectible/CollectibleCore.sol, manifold/contracts/collectible/ERC721Collectible.sol, manifold/contracts/collectible/ICollectibleCore.sol, manifold/contracts/collectible/IERC721Collectible.sol]
+confidence: high
+---
+
+# Collectible
+
+## What it is
+
+A **signature-gated paid drop** extension — a "Collection Drop" in the source. Unlike `[[lazy-payable-claim]]` (merkle allowlists), Collectible authorizes each mint with a **server-signed ECDSA message** bound to `msg.sender` and a one-time `nonce`. It supports a timed sale window with an optional **presale interval** (separate presale price/limits), an admin-only **premint** phase before activation, and an earlier free **claim** window. Shared singleton; instances keyed by `(creatorContractAddress, instanceId)`.
+
+## Contract map
+
+| File (relative to `packages/`) | Role |
+|---|---|
+| `manifold/contracts/collectible/CollectibleCore.sol` | `abstract` base: init, activation, signature/nonce validation, fee & membership, withdraw. Extends `AdminControl`. |
+| `manifold/contracts/collectible/ERC721Collectible.sol` | Concrete ERC721: `premint`, `claim`, `purchase`, `_mint`, tokenURI, transfer-lock hook. |
+| `manifold/contracts/collectible/ICollectibleCore.sol` | Core interface: `CollectibleInstance`/`CollectibleState`/param structs, events. |
+| `manifold/contracts/collectible/IERC721Collectible.sol` | ERC721 interface + `Unveil` event. |
+
+## Key structs (`collectible/ICollectibleCore.sol`)
+
+- `ActivationParameters { uint48 startTime; duration; presaleInterval; claimStartTime; claimEndTime; }`
+- `InitializationParameters { bool useDynamicPresalePurchaseLimit; uint16 transactionLimit, purchaseMax, purchaseLimit, presalePurchaseLimit; uint256 purchasePrice, presalePurchasePrice; address signingAddress; address payable paymentReceiver; }`
+- `UpdateInitializationParameters { ... same minus signingAddress/paymentReceiver }`
+- `CollectibleInstance` — full stored state (flags, limits, `purchaseCount`, timestamps, prices, `baseURI`, `paymentReceiver`).
+- `CollectibleState` — read model exposing `purchaseRemaining`.
+
+## External surface
+
+Core (`collectible/CollectibleCore.sol`):
+- `activate(address creatorContractAddress, uint256 instanceId, ActivationParameters)`
+- `deactivate(address creatorContractAddress, uint256 instanceId)`
+- `getCollectible(address creatorContractAddress, uint256 index) → CollectibleInstance`
+- `updateInitializationParameters(address, uint256, UpdateInitializationParameters)`
+- `updatePaymentReceiver(address, uint256, address payable)`
+- `setMembershipAddress(address)` · `withdraw(address payable, uint256)` · `nonceUsed(address, uint256, bytes32) → bool`
+
+ERC721 (`collectible/ERC721Collectible.sol`):
+- `initializeCollectible(address, uint256, InitializationParameters)`
+- `premint(address, uint256, uint16 amount)` **and** overloaded `premint(address, uint256, address[] addresses)`
+- `claim(address, uint256, uint16 amount, bytes32 message, bytes signature, bytes32 nonce)` — `payable`
+- `purchase(address, uint256, uint16 amount, bytes32 message, bytes signature, bytes32 nonce)` — `payable`
+- `setTokenURIPrefix(address, uint256, string)` · `setTransferLocked(address, uint256, bool)`
+- `state(address, uint256) → CollectibleState` · `purchaseRemaining(address, uint256) → uint16`
+- `tokenURI(address, uint256)` · `setApproveTransfer(address, bool)` · `approveTransfer(address, address, address, uint256)`
+
+## Distinctive mechanic
+
+**Signed message binds sender + nonce.** `_validatePurchaseRequest` recomputes `keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n52", msg.sender, nonce))` (52 bytes) and requires `message.recover(signature) == signingAddress`. The **with-amount** variant (`\n54`, appends `uint16 amount`) is used for dynamic presale limits. Nonces are single-use per `(creator, instanceId)`.
+
+**Three minting doors:**
+- `premint` — admin-only, **before** `isActive`; seeds tokens with no payment.
+- `claim` — signature-gated free mint inside `[claimStartTime, claimEndTime]`; caller pays only the Manifold fee (`msg.value == _getManifoldFee(amount)`).
+- `purchase` — signature-gated paid mint after `startTime`; branches on presale (`_isPresale`) vs regular price and enforces `transactionLimit`/`purchaseLimit`/`presalePurchaseLimit`.
+
+**Presale window:** `_isPresale` is true while `block.timestamp - startTime < presaleInterval`. `useDynamicPresalePurchaseLimit` switches presale to the amount-signed message path and skips static per-address counting.
+
+**Transfer lock:** `setTransferLocked` + the `approveTransfer` hook can freeze secondary transfers until the sale ends (mints from `address(0)` always pass).
+
+## Fee / membership handling
+
+`MINT_FEE = 690000000000000` wei (0.00069 ETH). `_getManifoldFee(numTokens)` returns `0` for active members else `MINT_FEE * numTokens`; membership checked via `IManifoldMembership.isActiveMember` at `manifoldMembershipContract`. `purchase` forwards `priceWithoutFee` to `paymentReceiver` and retains the fee (withdrawn by admin via `withdraw`).
+
+## Pitfalls
+
+- `purchaseMax != 0` doubles as the "initialized" sentinel (`_getInstance` reverts otherwise) — a zero max is impossible by design.
+- `activate` requires `startTime > block.timestamp`, `presaleInterval <= duration`, and `claimStartTime <= claimEndTime <= startTime`; misordered windows revert.
+- `updateInitializationParameters` only works while **inactive** and cannot change `signingAddress`/`paymentReceiver` (use `updatePaymentReceiver`).
+- Fee-only `claim` requires `msg.value` to equal exactly the fee — sending price too reverts.
+- Signature messages are `msg.sender`-bound: a signed payload cannot be relayed by another address.
+- For creator versions **< 3**, mint order is tracked in `_tokenIdToTokenClaimMap`; v3+ packs it into `tokenData` — tokenURI resolution handles both.
+
+## Open questions
+
+- No `IERC1155Collectible` present — is the ERC1155 variant intentionally absent from this family?
+- `endTime`/`presalePurchasePrice` are stored but the sale upper-bound is not enforced in `purchase` beyond `purchaseRemaining`; is end-time gating handled off-chain?
+
+## See also
+
+- `[[repo-overview]]` — family placement.
+- `[[lazy-payable-claim]]` — the merkle-based paid claim alternative.
+- `[[shared-libraries]]` — `IManifoldMembership` fee-waiver plumbing.

--- a/docs/llm-wiki/concepts/cross-chain-burn.md
+++ b/docs/llm-wiki/concepts/cross-chain-burn.md
@@ -1,0 +1,81 @@
+---
+title: Cross-Chain Burn
+created: 2026-07-15
+updated: 2026-07-15
+type: concept
+package: manifold
+tags: [contract, interface, cross-chain, burn-redeem, erc721, erc1155, signature, membership, struct, pitfall]
+sources: [manifold/contracts/crossChainBurn/CrossChainBurn.sol, manifold/contracts/crossChainBurn/ICrossChainBurn.sol, manifold/contracts/crossChainBurn/Interfaces.sol]
+confidence: high
+---
+
+# Cross-Chain Burn
+
+A **shared singleton** extension that lets a user **burn tokens on this chain** and have the **redeem happen on a different network/contract**. Unlike [[burn-redeem]], this contract does **not mint** the output — it only burns the inputs, records a per-instance count, and emits a `CrossChainBurn` event carrying the target `redeemContract` + `redeemNetworkId` for an off-chain/other-chain fulfiller to honor. Authorization comes from an **off-chain signer/oracle** rather than on-chain burn-set config. See [[repo-overview]] and [[shared-libraries]]; contrast the same-chain, config-driven [[burn-redeem]] family.
+
+## Contract map
+
+| File | Role |
+|---|---|
+| `crossChainBurn/CrossChainBurn.sol` | The whole extension: signature check, burn, count, event, receivers ^[manifold/contracts/crossChainBurn/CrossChainBurn.sol] |
+| `crossChainBurn/ICrossChainBurn.sol` | `BurnSubmission`/`BurnToken` structs, enums, errors, event, surface |
+| `crossChainBurn/Interfaces.sol` | `Burnable721`, `OZBurnable1155`, `Manifold1155` burn shims |
+
+Inherits `ICrossChainBurn, ReentrancyGuard, AdminControl`. State is minimal: `address _signingAddress`, `mapping(uint256 => mapping(address => mapping(uint256 => bool))) _usedTokens` (per instance→contract→tokenId, for the no-burn spec), and `mapping(uint256 => uint64) _totalCount`. Signer is set in the constructor `(initialOwner, signingAddress)`. ^[manifold/contracts/crossChainBurn/CrossChainBurn.sol#L19]
+
+## Key structs (from `ICrossChainBurn.sol`)
+
+- **`BurnToken`** — `address contractAddress; uint256 tokenId; TokenSpec tokenSpec; BurnSpec burnSpec; uint72 amount`. Note this points at a **concrete token**, not a validation rule (no merkle/range — the signer already decided eligibility). ^[manifold/contracts/crossChainBurn/ICrossChainBurn.sol#L70]
+- **`BurnSubmission`** — the signed authorization: `bytes signature; bytes32 message; uint256 instanceId; address redeemContract; uint256 redeemNetworkId; BurnToken[] burnTokens; uint64 redeemAmount; uint64 totalLimit; uint160 expiration`. ^[manifold/contracts/crossChainBurn/ICrossChainBurn.sol#L41]
+- `TokenSpec { INVALID, ERC721, ERC1155, ERC721_NO_BURN }` — note the extra `ERC721_NO_BURN`. `BurnSpec { INVALID, NONE, MANIFOLD, OPENZEPPELIN }`.
+- Event `CrossChainBurn(uint256 indexed instanceId, address indexed burnerAddress, address indexed redeemContract, uint256 redeemNetworkId, uint64 redeemAmount)`. ^[manifold/contracts/crossChainBurn/ICrossChainBurn.sol#L53]
+
+## External surface
+
+- `burnRedeem(BurnSubmission calldata submission)` `payable` — single. ^[manifold/contracts/crossChainBurn/CrossChainBurn.sol#L61]
+- `burnRedeem(BurnSubmission[] calldata submissions)` `payable` — batch; per entry it **skips silently** (no revert) when `_isAvailable` is false, so partial batches succeed. ^[manifold/contracts/crossChainBurn/CrossChainBurn.sol#L71]
+- `updateSigner(address)`, `withdraw(recipient, amount)`, `recover(tokenAddress, tokenId, destination)` — all `adminRequired`.
+- `getTotalCount(instanceId) → uint64`.
+- ERC721/ERC1155 receiver hooks for the send-in path.
+
+Flow per submission: `_isAvailable` (supply gate) → `_validateSubmission` (signature) → `_burnTokens` → `_redeem`. ^[manifold/contracts/crossChainBurn/CrossChainBurn.sol#L61]
+
+## Signature / authorization model
+
+This is the heart of the design. `_validateSubmission`: ^[manifold/contracts/crossChainBurn/CrossChainBurn.sol#L86]
+
+1. Reject if `block.timestamp > submission.expiration` (`ExpiredSignature`) or `redeemAmount == 0` (`InvalidInput`).
+2. Recompute `expectedMessage = keccak256(abi.encode(instanceId, burnTokens, redeemAmount, totalLimit, expiration))`.
+3. `signer = submission.message.recover(submission.signature)` (OZ `ECDSA`).
+4. Revert `InvalidSignature` unless `submission.message == expectedMessage` **and** `signer == _signingAddress`.
+
+So the trusted **Manifold signer/oracle** — which has observed the qualifying state on the *other* chain — issues an EIP-191 signature binding the exact burn set, amount, limit, and expiry. This contract trusts that signature; it performs **no on-chain proof** of cross-chain state itself. Supply is bounded by `_isAvailable`: if `totalLimit > 0` and `_totalCount[instanceId] + redeemAmount > totalLimit`, the redeem is unavailable. ^[manifold/contracts/crossChainBurn/CrossChainBurn.sol#L104]
+
+## How tokens are burned & received
+
+`_burn` dispatches on `tokenSpec`/`burnSpec` like [[burn-redeem]], with one extra mode: ^[manifold/contracts/crossChainBurn/CrossChainBurn.sol#L128]
+
+- `ERC1155`: `NONE`→transfer to `0xdEaD`; `MANIFOLD`/`OPENZEPPELIN`→`burn`.
+- `ERC721`: requires `amount == 1`; `NONE`→transfer to `0xdEaD`; else verify `ownerOf == from` then `Burnable721.burn`.
+- **`ERC721_NO_BURN`**: does **not** destroy the token — it verifies ownership and marks `_usedTokens[instanceId][contract][tokenId] = true`, reverting if already used. This "burns" the *right to redeem* while leaving the NFT intact (for tokens that can't be burned). ^[manifold/contracts/crossChainBurn/CrossChainBurn.sol#L163]
+
+Send-in path: `onERC721Received` / `onERC1155Received` / `onERC1155BatchReceived` `abi.decode` the full `BurnSubmission` from `data`, require a single `burnToken` (or matching length for batch), re-run availability + signature checks, verify `msg.sender`/`tokenId`/`amount` match the submission, burn from `address(this)`, then `_redeem`. ^[manifold/contracts/crossChainBurn/CrossChainBurn.sol#L230]
+
+`_redeem` merely `_totalCount[instanceId] += redeemAmount` and emits the event — **no minting occurs here.** ^[manifold/contracts/crossChainBurn/CrossChainBurn.sol#L332]
+
+## Fee & membership handling
+
+Both entrypoints are `payable`, but there is **no fee/cost logic** — no `BURN_FEE`, no membership check, no `paymentReceiver`. Any ETH sent simply accumulates and is recoverable via admin `withdraw`. `IManifoldMembership` is imported but not used for gating in the read source. This is a deliberate contrast with [[burn-redeem]], whose fees fund the platform. ^[manifold/contracts/crossChainBurn/CrossChainBurn.sol#L40]
+
+## Pitfalls
+
+- **The redeem is off-chain/other-chain.** This contract never mints — it emits `CrossChainBurn` for an external fulfiller. If the fulfiller stalls, the user has burned inputs with nothing on-chain to show for it.
+- **`ERC721_NO_BURN` uses `_usedTokens` per `instanceId`.** The same physical NFT can still be "used" in a *different* instanceId, and it is never actually consumed — design accordingly.
+- **Batch mode swallows unavailable entries.** `burnRedeem(BurnSubmission[])` silently skips any submission failing `_isAvailable` (only signature-validates the available ones), so a batch can partially execute without reverting. ^[manifold/contracts/crossChainBurn/CrossChainBurn.sol#L71]
+- **Trust is fully in `_signingAddress`.** A compromised or rotated signer changes who can authorize burns; there is no on-chain verification of the cross-chain claim.
+- **`message` is caller-supplied and re-derived.** Security rests on the `message == expectedMessage && signer == _signingAddress` conjunction — the raw `message` field alone is not trusted.
+
+## Open questions
+
+- Is `expiration` (`uint160`) compared against `block.timestamp` deliberately oversized, and what replay protection exists across chains beyond `totalLimit`/`_usedTokens`? ^[manifold/contracts/crossChainBurn/CrossChainBurn.sol#L87]
+- Nothing binds a submission to `msg.sender` in the signed `message`, so any address holding the burn tokens can submit a valid signature — intended?

--- a/docs/llm-wiki/concepts/deck-claims.md
+++ b/docs/llm-wiki/concepts/deck-claims.md
@@ -1,0 +1,73 @@
+---
+title: Deck Claims
+created: 2026-07-15
+updated: 2026-07-15
+type: concept
+package: manifold
+tags: [contract, abstract, interface, claim, deck, erc1155, signature, struct, pitfall]
+sources: [manifold/contracts/deckClaims/Deck.sol, manifold/contracts/deckClaims/ERC1155Deck.sol, manifold/contracts/deckClaims/IDeck.sol, manifold/contracts/deckClaims/IERC1155Deck.sol]
+confidence: high
+---
+
+# Deck Claims
+
+## What it is
+
+A **shared singleton** extension for "card-deck" style ERC-1155 claims. A creator initializes a claim that mints a fixed set of *variation* tokens (the "deck" — e.g. distinct cards). A trusted backend **signer** then deals those cards out to recipients via `deliverMints`. Unlike [[lazy-payable-claim]], **there is no user-facing on-chain mint or payment path** — all delivery is signer-driven and free at the contract level. Instances are keyed by `(creatorContractAddress, instanceId)`. See [[repo-overview]].
+
+## Contract map
+
+| File | Role |
+|------|------|
+| `deckClaims/IDeck.sol` | Base interface: errors, events, `VariationMint`/`ClaimMint` structs, signer/withdraw/deliver surface |
+| `deckClaims/IERC1155Deck.sol` | ERC-1155 interface: `Claim`, `ClaimParameters`, `UpdateClaimParameters`, init/update/getters |
+| `deckClaims/Deck.sol` | `abstract contract Deck is IDeck, AdminControl` — signer storage, `deprecate`, `withdraw`, `_validateSigner` |
+| `deckClaims/ERC1155Deck.sol` | Concrete `ERC1155Deck` — claim storage, init/update, `deliverMints`, `tokenURI` |
+
+## Key structs (from source)
+
+`Claim` (`IERC1155Deck.sol:13`): `StorageProtocol storageProtocol; uint32 total; uint80 startingTokenId; uint8 tokenVariations; string location;`
+
+`ClaimParameters` (`IERC1155Deck.sol:21`): `StorageProtocol storageProtocol; uint8 tokenVariations; string location;`
+
+`VariationMint` (`IDeck.sol:34`): `uint8 variationIndex; uint32 amount; address recipient;`
+
+`ClaimMint` (`IDeck.sol:40`): `address creatorContractAddress; uint256 instanceId; VariationMint[] variationMints;`
+
+Note: no `cost`, `paymentReceiver`, `startDate`/`endDate`, or `totalMax` — Deck has **no pricing or supply-cap fields at all**.
+
+## External surface (traced)
+
+- `initializeClaim(address, uint256, ClaimParameters) external payable creatorAdminRequired` — `ERC1155Deck.sol:43`
+- `updateClaim(address, uint256, UpdateClaimParameters) external creatorAdminRequired` — `ERC1155Deck.sol:86`
+- `deliverMints(ClaimMint[] calldata) external` — `ERC1155Deck.sol:135` (signer-only)
+- `getClaim` / `getClaimForToken` — `ERC1155Deck.sol:112` / `:119`
+- `updateTokenURIParams(...) creatorAdminRequired` — `ERC1155Deck.sol:192`
+- `tokenURI(address, uint256)` — `ERC1155Deck.sol:175`
+- From `Deck.sol`: `setSigner(address) adminRequired` (`:61`), `withdraw(address payable, uint256) adminRequired` (`:53`), `deprecate(bool) adminRequired` (`:46`)
+
+## The distinctive mechanic: dealing a deck
+
+1. `initializeClaim` mints `tokenVariations` **new** token IDs on the creator contract via `mintExtensionNew(receivers, amounts, uris)` with **all-zero amounts and empty URIs** (`ERC1155Deck.sol:59-61`). These are the deck's card slots. Only `newTokenIds[0]` is stored as `startingTokenId`; each of the `tokenVariations` token IDs is mapped back to the instance in `_tokenInstances` (`:73-78`).
+2. Card token for a variation is computed as `startingTokenId + variationIndex - 1` (`ERC1155Deck.sol:155`) — so `variationIndex` is **1-based** and validated `>= 1 && <= tokenVariations` (`:149`).
+3. The backend decides *who gets which card* off-chain, then the **signer** calls `deliverMints`, which loops variations and calls `mintExtensionExisting` to mint the dealt cards to recipients (`:165`). `claim.total` accumulates delivered supply.
+
+`tokenURI` returns `prefix + location + "/" + (tokenId - startingTokenId + 1)` (`ERC1155Deck.sol:186`), i.e. metadata index is the 1-based variation number.
+
+## Fee & membership handling
+
+None on-chain. There is **no mint fee, no cost, no membership/fee-waiver logic** — contrast with [[gacha-serendipity]] (`MINT_FEE`) and [[lazy-payable-claim]]. `withdraw` exists only to sweep any stray ETH sent to the contract.
+
+## Pitfalls
+
+- **No user mint entrypoint.** Collectors cannot mint directly; everything flows through the off-chain backend + `deliverMints`. A compromised or offline signer fully controls distribution.
+- `deliverMints` performs **no per-recipient reservation or cap check** (unlike Serendipity's `reservedCount`). The signer is fully trusted to mint the right amounts.
+- `variationIndex` bound check is `variationIndex > MAX_UINT_8` then `> claim.tokenVariations` — the first is redundant since the field is `uint8`.
+- `initializeClaim` is `payable` but consumes no value.
+
+## Open questions
+
+- Where does the randomness/fairness of "which card" live? Entirely off-chain in the signer service; not verifiable on-chain.
+- `updateClaim` cannot change `tokenVariations` or `startingTokenId` — how are new cards added to an existing deck? Apparently not supported.
+
+See also: [[gacha-serendipity]], [[frame-claims]], [[shared-libraries]].

--- a/docs/llm-wiki/concepts/dynamic-and-enumerable.md
+++ b/docs/llm-wiki/concepts/dynamic-and-enumerable.md
@@ -1,0 +1,69 @@
+---
+title: Dynamic & Enumerable Packages
+created: 2026-07-15
+updated: 2026-07-15
+type: concept
+package: dynamic
+tags: [contract, abstract, dynamic-token, enumerable, erc721, library, pitfall]
+sources: [dynamic/contracts/DynamicArweaveHash.sol, dynamic/contracts/DynamicSVGExample.sol, dynamic/contracts/TimeToken.sol, enumerable/contracts/ERC721/ERC721OwnerEnumerableExtension.sol, enumerable/contracts/ERC721/ERC721OwnerEnumerableSingleCreatorExtension.sol]
+confidence: high
+---
+
+# Dynamic & Enumerable Packages
+
+Two independent extension families for Manifold ERC721 creator contracts. **Dynamic** computes `tokenURI` on-chain so metadata can change over time or by owner. **Enumerable** adds per-owner token enumeration the base creator contract does not natively provide. See [[repo-overview]], [[shared-libraries]].
+
+---
+
+## Section 1 — Dynamic (on-chain / mutable tokenURI)
+
+### What it is
+Extensions implementing `ICreatorExtensionTokenURI.tokenURI` to return metadata built at read time rather than a static stored URI. Three examples, from simplest to most elaborate.
+
+### Contract map
+- `dynamic/contracts/DynamicArweaveHash.sol` — abstract base. Stores `string[] imageArweaveHashes` / `animationArweaveHashes` and builds a `data:application/json` URI pointing at `https://arweave.net/<hash>`. Owner can swap the hash arrays. Abstract hooks: `_getName`, `_getDescription`, `_getImageHash`, `_getAnimationHash`.
+- `dynamic/contracts/TimeToken.sol` — concrete `DynamicArweaveHash`. Selects which Arweave hash to serve by elapsed time: `(block.timestamp - _creationTimestamp)/_cadence % hashes.length`. Single-token (`mint` guards `_tokenId == 0`).
+- `dynamic/contracts/DynamicSVGExample.sol` — fully **on-chain SVG**. Assembles an animated `<svg>` from `_imageParts` with tag substitution (`<RADIUS>`, `<HUE1>`…`<LIGHTNESS2>`), coloring derived from the owner's address bytes and a time-based `completion` curve using `ABDKMath64x64` fixed-point math. Also implements `IERC721CreatorExtensionApproveTransfer` to capture creation/completion timestamps on first transfer.
+
+### External surface (traced)
+- `DynamicArweaveHash`: `tokenURI(address,uint256)`, `setImageArweaveHashes(string[])` (onlyOwner), `setAnimationAreaveHashes(string[])` (onlyOwner) — note the misspelled setter name.
+- `TimeToken`: `constructor(address creator, string name, string description, uint256 cadence)`, `mint(address) returns(uint256)`.
+- `DynamicSVGExample`: `mint(address)` (onlyOwner), `tokenURI(address,uint256)`, `updateImageParts(string[])`, `setApproveTransfer(address,bool)`, `approveTransfer(address,address,address,uint256)`.
+
+### Distinctive mechanic
+`DynamicSVGExample` reads `IERC721(creator).ownerOf(tokenId)` inside `tokenURI` and folds the low bytes of the owner address into hue/offset — so the image visibly changes when the token changes hands. The `completion` factor decays over ~1 year (`31536000` seconds); `approveTransfer` sets `_completionTimestamp = block.timestamp + 31536000` on the first tracked transfer.
+
+### Pitfalls
+- Owner-dependent rendering means `tokenURI` output is **not stable** — marketplaces caching metadata will show stale art after transfers.
+- On-chain SVG is gas-heavy to read and depends on `ABDKMath64x64`; the file has a real-looking constant `315...6000` for one year — verify no precision surprises.
+- `TimeToken` will revert on `_getImageHash`/`_getAnimationHash` if the corresponding hash array is empty (modulo by zero / index).
+
+---
+
+## Section 2 — Enumerable (per-owner enumeration)
+
+### What it is
+Adds `tokenOfOwnerByIndex` / `balanceOf(owner)` for tokens an extension mints, by hooking `approveTransfer` on the creator contract. The base ERC721 creator core does not track per-owner token lists for extension-minted tokens; this fills the gap via swap-and-pop arrays.
+
+### Contract map
+- `enumerable/contracts/ERC721/ERC721OwnerEnumerableExtension.sol` — abstract, **multi-creator** keyed by creator address: `balanceOf(creator,owner)`, `tokenOfOwnerByIndex(creator,owner,index)`. Call `_activate(creator)` per creator.
+- `enumerable/contracts/ERC721/ERC721OwnerEnumerableSingleCreatorExtension.sol` — two contracts in one file: `ERC721OwnerEnumerableSingleCreatorBase` (single-creator, `balanceOf(owner)` / `tokenOfOwnerByIndex(owner,index)`, and `approveTransfer` requires `msg.sender == _creator`) and `ERC721OwnerEnumerableSingleCreatorExtension` wiring in `ERC721SingleCreatorExtension`.
+
+### External surface (traced)
+- Multi: `tokenOfOwnerByIndex(address creator,address owner,uint256 index)`, `balanceOf(address creator,address owner)`, `approveTransfer(address,address from,address to,uint256 tokenId)`.
+- Single: `tokenOfOwnerByIndex(address owner,uint256 index)`, `balanceOf(address owner)`, `approveTransfer(...)`.
+- Internal mint helpers `_mintExtension(...)` / `_mintExtensionBatch(...)` add tokens to enumeration as they mint.
+
+### Distinctive mechanic
+`approveTransfer` is the enumeration engine: on mint (`from == address(0)`) it returns early (mint helpers already indexed the token); on transfer it removes from `from` and adds to `to` using swap-and-pop (`_removeTokenFromOwnerEnumeration`). Enumeration only works after `_activate` calls `setApproveTransferExtension(true)` on the creator.
+
+### Pitfalls
+- **Must call `_activate`** (per creator for the multi-creator variant) or `approveTransfer` is never invoked and counts stay zero — flagged IMPORTANT in-source.
+- The multi-creator `approveTransfer` does **not** check `msg.sender == creator` (uses `msg.sender` as creator key), unlike the single-creator base which requires it — mixing them or trusting the multi variant's caller is a footgun.
+- Only tokens minted through this extension's `_mintExtension*` helpers are enumerated; externally-minted tokens on the same creator are invisible here.
+
+## Open questions
+- Does any shipped concrete contract combine Enumerable + Dynamic, or are they always used separately?
+- `DynamicSVGExample` completion math relies on ABDK `log_2` of `completion` which can be ≤0 near completion — confirm domain safety.
+
+See also: [[repo-overview]], [[shared-libraries]], [[editions-and-singles]].

--- a/docs/llm-wiki/concepts/edition-package.md
+++ b/docs/llm-wiki/concepts/edition-package.md
@@ -1,0 +1,54 @@
+---
+title: Edition Package (Numbered & Prefix Editions)
+created: 2026-07-15
+updated: 2026-07-15
+type: concept
+package: edition
+tags: [contract, abstract, interface, edition, erc721, struct, pitfall]
+sources: [edition/contracts/ERC721EditionBase.sol, edition/contracts/IERC721Edition.sol, edition/contracts/ERC721NumberedEditionBase.sol, edition/contracts/IERC721NumberedEdition.sol, edition/contracts/ERC721NumberedEdition.sol, edition/contracts/ERC721NumberedEditionImplementation.sol, edition/contracts/ERC721NumberedEditionTemplate.sol, edition/contracts/ERC721PrefixEditionBase.sol, edition/contracts/IERC721PrefixEdition.sol, edition/contracts/nifty/NiftyGatewayERC721NumberedEditionImplementation.sol, edition/contracts/nifty/INiftyGatewayERC721NumberedEdition.sol]
+confidence: high
+---
+
+# Edition Package (Numbered & Prefix Editions)
+
+## What it is
+Extensions for minting fixed-supply **editions** on a Manifold ERC721 creator contract. An edition has a `maxSupply`, tracks `totalSupply`, and computes each token's *edition index* from its tokenId. Two URI styles: **numbered** (a templated JSON `data:` URI with `<EDITION>/<TOTAL>/<MAX>` tag substitution) and **prefix** (a base string + edition number appended). Ships in three deployment shapes — direct contract, minimal-proxy Implementation, and Template — plus a Nifty Gateway variant. Related: [[editions-and-singles]], [[repo-overview]].
+
+## Contract map
+- `edition/contracts/ERC721EditionBase.sol` — abstract core. Supply accounting + `IndexRange[]` bookkeeping to map tokenId → sequential edition index. Implements `ICreatorExtensionTokenURI`.
+- `edition/contracts/IERC721Edition.sol` — `mint` (single + multi-recipient), `totalSupply`, `maxSupply`.
+- `edition/contracts/ERC721NumberedEditionBase.sol` — abstract; tag-substitution URI builder over `string[] _uriParts`.
+- `edition/contracts/ERC721NumberedEdition.sol` — concrete, constructor-initialized, `AdminControl`.
+- `edition/contracts/ERC721NumberedEditionImplementation.sol` — concrete clone target, `AdminControlUpgradeable`, `initializer`.
+- `edition/contracts/ERC721NumberedEditionTemplate.sol` — EIP-1967 minimal proxy that hard-codes `uriParts` and delegatecalls `initialize`.
+- `edition/contracts/ERC721PrefixEditionBase.sol` — abstract; `tokenURI = prefix + (index+1)`. (`Base/Implementation/Template` mirror the numbered trio.)
+- `edition/contracts/IERC721PrefixEdition.sol` — adds `setTokenURIPrefix(string)`.
+- `edition/contracts/nifty/NiftyGatewayERC721NumberedEditionImplementation.sol` — Nifty Gateway minter-gated variant.
+
+## Key structs / interfaces
+- `ERC721EditionBase.IndexRange { uint256 startIndex; uint256 count; }` — coalesced runs of minted tokenIds; used by `_tokenIndex` to derive the 0-based edition index (URI adds `+1`).
+- Numbered tags: `_EDITION_TAG='<EDITION>'`, `_TOTAL_TAG='<TOTAL>'`, `_MAX_TAG='<MAX>'`.
+- `INiftyGatewayERC721NumberedEdition`: `activate(address[],address)`, `mintNifty(uint256,uint16)`, `_mintCount(uint256)`.
+
+## External surface (traced)
+Common (`IERC721Edition`): `mint(address recipient, uint16 count)`, `mint(address[] recipients)`, `totalSupply()`, `maxSupply()`.
+Numbered concrete/impl: `updateURIParts(string[])` + the two `mint` overloads, all `adminRequired`; `Implementation.initialize(address creator, uint256 maxSupply_, string[] uriParts)` is `initializer`.
+Prefix: adds `setTokenURIPrefix(string)`.
+Nifty impl: `activate(address[] minters, address niftyOmnibusWallet)`, `mintNifty(uint256 niftyType, uint16 count)` (requires `niftyType == 1` and caller in `_minters`), `_mintCount(uint256)`, plus `updateURIParts`/`mint`.
+All: `tokenURI(address creator, uint256 tokenId)` via `ICreatorExtensionTokenURI`.
+
+## Distinctive mechanic — clone/template pattern
+`ERC721NumberedEditionTemplate` is an OpenZeppelin `Proxy` writing `editionImplementation` into the EIP-1967 `_IMPLEMENTATION_SLOT` (`0x360894...382bbc`), then `Address.functionDelegateCall`-ing `initialize(address,uint256,string[])` in its constructor — the `uriParts` are baked into the template's bytecode. `Implementation` uses `AdminControlUpgradeable` + `initializer` (no constructor state) so it is safe to clone. The plain `ERC721NumberedEdition` skips proxying and initializes in its constructor. Numbered vs prefix differ only in the `tokenURI` builder: numbered walks `_uriParts` doing `keccak256` tag comparison and substituting `(tokenIndex+1)`, `_totalSupply`, `_maxSupply`; prefix just concatenates.
+
+## Pitfalls
+- `_tokenIndex` reverts "Invalid token" for any tokenId not in a recorded `IndexRange`; ranges only coalesce when mints are contiguous (`ERC721EditionBase.sol` lines 78–83) — interleaved mints from other extensions create multiple ranges.
+- Template bakes `uriParts` at deploy — changing metadata later still requires `updateURIParts` (admin) on the proxy.
+- `_mint(address[])` mints one-by-one via `mintExtension` (no batch), so gas scales with recipient count; `_mint(recipient,count)` uses `mintExtensionBatch`.
+- Nifty variant: `mintNifty` only supports `niftyType == 1` and mints to the fixed `_niftyOmnibusWallet` set at `activate`.
+- `initialize`/`_initialize` guard on `_creator == address(0)` — cannot re-initialize a clone.
+
+## Open questions
+- Numbered `<EDITION>` is `index+1` while `<MAX>` is `_maxSupply`; confirm intended display when supply < max (open editions).
+- Nifty `_mintCount` returns `_totalSupply` regardless of type — is per-type accounting ever needed?
+
+See also: [[repo-overview]], [[editions-and-singles]], [[shared-libraries]].

--- a/docs/llm-wiki/concepts/editions-and-singles.md
+++ b/docs/llm-wiki/concepts/editions-and-singles.md
@@ -1,0 +1,85 @@
+---
+title: Editions and Singles
+created: 2026-07-15
+updated: 2026-07-15
+type: concept
+package: manifold
+tags: [contract, interface, edition, single, erc721, erc1155, struct, pitfall]
+sources: [manifold/contracts/edition/ManifoldERC721Edition.sol, manifold/contracts/edition/IManifoldERC721Edition.sol, manifold/contracts/single/ManifoldERC721Single.sol, manifold/contracts/single/ManifoldERC1155Single.sol, manifold/contracts/single/IManifoldERC721Single.sol, manifold/contracts/single/IManifoldERC1155Single.sol]
+confidence: high
+---
+
+# Editions and Singles
+
+## What it is
+
+Two admin-only minting extensions for Manifold Creator Core contracts. **Edition** batch-mints a numbered series (`1..maxSupply`) of ERC721 tokens sharing one metadata prefix. **Single** performs a one-off 1/1 mint (ERC721 `mintBase` or ERC1155 `mintBaseNew`). Both are shared singletons — every function is keyed by `creatorCore` and gated by `creatorAdminRequired`. Neither takes payment: these are pure creator distribution tools, not paid claim pages. Compare with the older, separate `[[edition-package]]`.
+
+## Contract map
+
+| File (relative to `packages/`) | Role |
+|---|---|
+| `manifold/contracts/edition/ManifoldERC721Edition.sol` | Edition controller; `CreatorExtension` + `ICreatorExtensionTokenURI` + `ReentrancyGuard`. Batch mint, tokenURI resolution. |
+| `manifold/contracts/edition/IManifoldERC721Edition.sol` | Edition interface: `EditionInfo`/`Recipient`/`IndexRange` structs, errors, `SeriesCreated` event. |
+| `manifold/contracts/single/ManifoldERC721Single.sol` | ERC721 1/1 mint via `mintBase`. |
+| `manifold/contracts/single/ManifoldERC1155Single.sol` | ERC1155 mint via `mintBaseNew` (multi-recipient/amount). |
+| `manifold/contracts/single/IManifoldERC721Single.sol` | ERC721 single interface. |
+| `manifold/contracts/single/IManifoldERC1155Single.sol` | ERC1155 single interface. |
+
+## Key structs (edition)
+
+`edition/IManifoldERC721Edition.sol`:
+- `EditionInfo { uint192 firstTokenId; uint8 contractVersion; uint24 totalSupply; uint24 maxSupply; StorageProtocol storageProtocol; string location; }`
+- `Recipient { address recipient; uint16 count; }`
+- `enum StorageProtocol { INVALID, NONE, ARWEAVE, IPFS }`
+- `IndexRange { uint256 startIndex; uint256 count; }` (defined in the impl, `ManifoldERC721Edition.sol`)
+
+## External surface
+
+Edition — `edition/ManifoldERC721Edition.sol`:
+- `createSeries(address creatorCore, uint256 instanceId, uint24 maxSupply_, StorageProtocol storageProtocol, string location, Recipient[] recipients)`
+- `setTokenURI(address creatorCore, uint256 instanceId, StorageProtocol storageProtocol, string location)`
+- `mint(address creatorCore, uint256 instanceId, uint24 currentSupply, Recipient[] recipients)` — `nonReentrant`
+- `getEditionInfo(address creatorCore, uint256 instanceId) → EditionInfo`
+- `getInstanceIdsForTokens(address creatorCore, uint256[] tokenIds) → uint256[]`
+- `getInstanceTokenIds(address creatorCore, uint256 instanceId) → uint256[]`
+- `tokenURI(address creatorCore, uint256 tokenId) → string`
+
+Single — `single/ManifoldERC721Single.sol`:
+- `mint(address creatorCore, uint256 expectedTokenId, string uri, address recipient)`
+
+Single — `single/ManifoldERC1155Single.sol`:
+- `mint(address creatorCore, uint256 expectedTokenId, string uri, address[] recipients, uint256[] amounts)`
+
+## Distinctive mechanic
+
+**Version-dependent token indexing (edition).** Two storage strategies switch on the creator contract's `VERSION()`:
+- **v3+**: the per-token index is packed into `tokenData` as `uint56(instanceId) << 24 | uint24(mintIndex)` and written at mint via `mintExtensionBatch`. No auxiliary storage. See `_mintTokens` in `edition/ManifoldERC721Edition.sol`.
+- **< v3**: no per-token data slot, so the extension records `IndexRange[]` per instance and reverse-derives `(instanceId, index)` by scanning `_creatorInstanceIds` in `_tokenInstanceAndIndex`.
+
+`tokenURI` returns `prefix + location + "/" + (index+1)`, prefix chosen from `StorageProtocol` (Arweave/IPFS/none). Editions are 1-indexed in the URI.
+
+**Expected-id assertion (single & edition mint).** Single's `mint` reverts with `InvalidInput()` if the freshly minted id ≠ `expectedTokenId`; edition's `mint` reverts if `currentSupply != info.totalSupply`. Both are optimistic-concurrency guards so a caller's off-chain assumption can't silently drift.
+
+## Fee / membership handling
+
+None. Neither extension is payable, references `MINT_FEE`, nor touches Manifold Membership. Access control is the only gate. Contrast with `[[collectible]]`.
+
+## Pitfalls
+
+- `createSeries` requires `instanceId` in `(0, MAX_UINT_56]` and rejects a re-used instanceId (existing `storageProtocol != INVALID`) — one series per id.
+- Edition `mint`'s `currentSupply` argument must exactly equal the on-chain `totalSupply` or it reverts; callers must read current supply first.
+- For creator versions **< 3**, instanceIds are pushed to `_creatorInstanceIds` and token→instance lookups are an O(series × ranges) scan — gas grows with history.
+- Single mint's `expectedTokenId` must be predicted correctly by the caller; a concurrent mint on the creator contract shifts the id and reverts the tx.
+- `getInstanceTokenIds` for v3+ linearly walks token ids from `firstTokenId` until `totalSupply` matches — unbounded scan for sparse mints.
+
+## Open questions
+
+- No burn or supply-reduction path — is a series immutable in size once `maxSupply` is set? (Appears yes.)
+- `StorageProtocol.NONE` yields an empty prefix; is a fully-qualified `location` expected in that mode?
+
+## See also
+
+- `[[repo-overview]]` — where these sit among the extension families.
+- `[[edition-package]]` — the older, separate edition implementation for comparison.
+- `[[collectible]]` — the payable claim/purchase cousin.

--- a/docs/llm-wiki/concepts/frame-claims.md
+++ b/docs/llm-wiki/concepts/frame-claims.md
@@ -1,0 +1,86 @@
+---
+title: Farcaster Frame Claims
+created: 2026-07-15
+updated: 2026-07-15
+type: concept
+package: manifold
+tags: [contract, abstract, interface, claim, frame, erc1155, signature, fee, struct, pitfall]
+sources: [manifold/contracts/frameclaims/FrameLazyClaim.sol, manifold/contracts/frameclaims/ERC1155FrameLazyClaim.sol, manifold/contracts/frameclaims/FramePaymaster.sol, manifold/contracts/frameclaims/IFrameLazyClaim.sol, manifold/contracts/frameclaims/IERC1155FrameLazyClaim.sol, manifold/contracts/frameclaims/IFramePaymaster.sol]
+confidence: high
+---
+
+# Farcaster Frame Claims
+
+## What it is
+
+A **shared singleton** extension for minting ERC-1155 claims from **Farcaster Frames**. Because a Frame interaction has no on-chain signature from the user, mints are **relayed**: a trusted **signer/paymaster** authorizes and submits the mint on the user's behalf. Two contracts collaborate — `ERC1155FrameLazyClaim` (the extension holding claims) and `FramePaymaster` (the relayer that verifies a backend signature bound to a Farcaster `fid` + nonce). Instances keyed by `(creatorContractAddress, instanceId)`. A relayed variant of the [[lazy-payable-claim]] family; see [[repo-overview]].
+
+## Contract map
+
+| File | Role |
+|------|------|
+| `frameclaims/IFrameLazyClaim.sol` | Base interface: `Recipient`/`Mint` structs, sponsor/signer/mint surface, errors, events |
+| `frameclaims/IERC1155FrameLazyClaim.sol` | ERC-1155 `Claim`/`ClaimParameters`, init/getters |
+| `frameclaims/FrameLazyClaim.sol` | `abstract FrameLazyClaim is IFrameLazyClaim, AdminControl` — signer, funds receiver, `SPONSORED_MINT_FEE`, `MANIFOLD_FREE_MINTS` |
+| `frameclaims/ERC1155FrameLazyClaim.sol` | Concrete extension: claim storage, `mint` (signer-only), `sponsorMints`, `tokenURI` |
+| `frameclaims/IFramePaymaster.sol` | Paymaster interface: `MintSubmission`/`ExtensionMint`/`Mint`, `checkout`/`deliver` |
+| `frameclaims/FramePaymaster.sol` | Relayer: signature + nonce verification, fans out to extension `mint` |
+
+## Key structs (from source)
+
+`Claim` (`IERC1155FrameLazyClaim.sol:21`): `StorageProtocol storageProtocol; string location; uint256 tokenId; address payable paymentReceiver; uint56 sponsoredMints;`
+
+`IFrameLazyClaim.Recipient` (`:23`): `address receiver; uint256 amount; uint256 payment;`
+`IFrameLazyClaim.Mint` (`:29`): `address creatorContractAddress; uint256 instanceId; Recipient[] recipients;`
+
+`IFramePaymaster.MintSubmission` (`:22`): `ExtensionMint[] extensionMints; uint256 fid; uint256 nonce; uint256 expiration; bytes32 message; bytes signature;`
+`ExtensionMint` (`:31`): `address extensionAddress; Mint[] mints;`
+`IFramePaymaster.Mint` (`:36`): `address creatorContractAddress; uint256 instanceId; uint256 amount; uint256 payment;`
+
+## External surface (traced)
+
+**Extension (`ERC1155FrameLazyClaim.sol`):**
+- `initializeClaim(address, uint256, ClaimParameters) external payable creatorAdminRequired` — `:41`
+- `mint(Mint[] calldata) external payable` — `:132` (**signer-only**, `_validateSigner`)
+- `sponsorMints(address, uint256, uint56) external payable creatorAdminRequired` — `:148`
+- `updateTokenURIParams` / `extendTokenURI` / `getClaim` / `getClaimForToken` / `tokenURI`
+- From `FrameLazyClaim.sol`: `setSigner adminRequired` (`:62`), `setFundsReceiver adminRequired` (`:69`), `updateSponsoredMintFee adminRequired` (`:48`), `updateManifoldFreeMints adminRequired` (`:55`).
+
+**Paymaster (`FramePaymaster.sol`):**
+- `checkout(MintSubmission calldata) external payable` — `:63` (user-facing relay entry)
+- `deliver(address extensionAddress, Mint[] calldata) external` — `:55` (**signer-only** direct delivery)
+- `setSigner adminRequired` (`:47`), `withdraw adminRequired` (`:39`)
+
+## The distinctive mechanic: paymaster authorization
+
+The extension's `mint` **only accepts calls from `_signer`** (`ERC1155FrameLazyClaim.sol:133` → `_validateSigner`). Two authorized paths reach it:
+
+1. **`FramePaymaster.checkout`** — the collector (or a relayer) submits a `MintSubmission`. `_validateCheckout` (`FramePaymaster.sol:96`) enforces:
+   - `block.timestamp <= expiration` else `ExpiredSignature` (`:97`).
+   - Recomputes `expectedMessage = keccak256(abi.encodePacked(abi.encode(extensionMints, fid, expiration, nonce, msg.value)))` and requires `submission.message == expectedMessage` **and** `message.recover(signature) == _signer` (`:99-101`). Payment (`msg.value`) is bound into the signed message.
+   - **Nonce replay protection keyed by `(fid, nonce)`**: `_usedNonces[fid][nonce]` must be false, then set true (`:102-103`).
+   Checkout then loops extensions, builds `Recipient{ receiver: msg.sender, ... }`, and calls `extension.mint{value: extensionPayment}(mints)` (`:89`). The paymaster must itself be set as the extension's signer for this to succeed.
+2. **`FramePaymaster.deliver`** — backend-only (`msg.sender == _signer`) direct call that forwards to `extension.mint` with pre-built recipients, used when Manifold sponsors/relays the mint entirely off the user's payment.
+
+Inside the extension, `_mintClaim` (`:160`) sums `recipients[].payment`, requires `paymentReceived >= totalPayment`, mints via `mintExtensionExisting`, and forwards `totalPayment` to `claim.paymentReceiver`.
+
+## Fee & membership handling
+
+- **Sponsored mints:** `MANIFOLD_FREE_MINTS = 5` are free; beyond that each sponsored mint costs `SPONSORED_MINT_FEE = 0.0001 ETH` (`FrameLazyClaim.sol:27-28`). Charged at `initializeClaim` (`:53-54`) and `sponsorMints` (`:149`), forwarded to `_fundsReceiver`.
+- A claim is **either** paid (`paymentReceiver` set) **or** sponsored (`sponsoredMints > 0`) — never both (`ERC1155FrameLazyClaim.sol:51`).
+- Per-mint collector payment flows to `claim.paymentReceiver`; no merkle allowlist or delegation.
+
+## Pitfalls
+
+- **Signer = single point of trust.** The extension mints for anyone the signer authorizes; the paymaster's ECDSA check is the only gate on `checkout`. Compromise the backend key and arbitrary mints are possible.
+- `message.recover(signature)` is applied to the **raw `bytes32`** with no EIP-191 (`\x19Ethereum Signed Message`) prefix — backend signing must match exactly.
+- `msg.value` is folded into the signed message, so any payment mismatch invalidates the signature (good), but also means the exact value must be known at signing time.
+- The paymaster must be registered as the extension's `_signer` (`setSigner`) for `checkout` to work; otherwise `checkout` reverts on the extension's `_validateSigner`.
+- `tokenURI` returns `prefix + location` with **no token index** (single token per claim; `Claim.tokenId`).
+
+## Open questions
+
+- Absence of an EIP-191/EIP-712 prefix on the checkout signature — intentional (backend-controlled) but reduces interoperability with standard wallet signers.
+- `fid` is recorded/emitted but not otherwise bound to the receiver on-chain; Farcaster identity ↔ wallet mapping is a backend concern.
+
+See also: [[deck-claims]], [[gacha-serendipity]], [[shared-libraries]].

--- a/docs/llm-wiki/concepts/gacha-serendipity.md
+++ b/docs/llm-wiki/concepts/gacha-serendipity.md
@@ -1,0 +1,78 @@
+---
+title: Gacha / Serendipity Claims
+created: 2026-07-15
+updated: 2026-07-15
+type: concept
+package: manifold
+tags: [contract, abstract, interface, claim, gacha, erc1155, signature, fee, struct, pitfall]
+sources: [manifold/contracts/gachaclaims/Serendipity.sol, manifold/contracts/gachaclaims/ERC1155Serendipity.sol, manifold/contracts/gachaclaims/ISerendipity.sol, manifold/contracts/gachaclaims/IERC1155Serendipity.sol]
+confidence: high
+---
+
+# Gacha / Serendipity Claims
+
+## What it is
+
+A **shared singleton** gacha ("lucky draw") extension for ERC-1155. A collector pays to **reserve** a number of mints; a trusted backend **signer** later randomizes which variation each reservation resolves to and **delivers** the tokens. The randomization itself is **off-chain** — the contract only enforces payment, supply caps, and a reserve/deliver accounting invariant. Instances keyed by `(creatorContractAddress, instanceId)`. It is a payment-bearing sibling of [[deck-claims]] and a variant of the [[lazy-payable-claim]] family. See [[repo-overview]].
+
+## Contract map
+
+| File | Role |
+|------|------|
+| `gachaclaims/ISerendipity.sol` | Base interface: errors, events, `VariationMint`/`ClaimMint`/`UserMintDetails`, `mintReserve`/`deliverMints` surface |
+| `gachaclaims/IERC1155Serendipity.sol` | ERC-1155 `Claim`, `ClaimParameters`, `UpdateClaimParameters`, init/update/getters |
+| `gachaclaims/Serendipity.sol` | `abstract Serendipity is ISerendipity, AdminControl` — `MINT_FEE`, per-wallet mint accounting, signer, `_sendFunds` |
+| `gachaclaims/ERC1155Serendipity.sol` | Concrete `ERC1155Serendipity` — claim storage, `mintReserve`, `deliverMints`, `tokenURI` |
+
+## Key structs (from source)
+
+`Claim` (`IERC1155Serendipity.sol:13`): `StorageProtocol storageProtocol; uint32 total; uint32 totalMax; uint48 startDate; uint48 endDate; uint80 startingTokenId; uint8 tokenVariations; string location; address payable paymentReceiver; uint96 cost; address erc20;`
+
+`ClaimParameters` (`:27`) mirrors `Claim` minus `total`/`startingTokenId`.
+
+`UserMintDetails` (`ISerendipity.sol:63`): `uint32 reservedCount; uint32 deliveredCount;`
+
+`VariationMint` (`ISerendipity.sol:51`): `uint8 variationIndex; uint32 amount; address recipient;`
+
+`ClaimMint` (`ISerendipity.sol:57`): `address creatorContractAddress; uint256 instanceId; VariationMint[] variationMints;`
+
+## External surface (traced)
+
+- `initializeClaim(address, uint256, ClaimParameters) external payable creatorAdminRequired` — `ERC1155Serendipity.sol:45`
+- `updateClaim(address, uint256, UpdateClaimParameters) external creatorAdminRequired` — `:99`
+- `mintReserve(address, uint256, uint32 mintCount) external payable` — `:159` (user entrypoint)
+- `deliverMints(ClaimMint[] calldata) external` — `:190` (signer-only)
+- `getUserMints(address, address, uint256)` — `:233`
+- `getClaim` / `getClaimForToken` / `tokenURI` / `updateTokenURIParams`
+- From `Serendipity.sol`: `setSigner adminRequired` (`:68`), `withdraw adminRequired` (`:60`), `deprecate adminRequired` (`:53`); constant `MINT_FEE = 500000000000000` (0.0005 ETH, `:28`).
+
+## The distinctive mechanic: randomness + supply
+
+**Reserve (on-chain), then deliver (off-chain-randomized):**
+
+1. `mintReserve` (`ERC1155Serendipity.sol:159`) requires `!Address.isContract(msg.sender)` (`:160`, blocks contract callers so tx-hash entropy can't be gamed by a contract), checks the claim window (`startDate`/`endDate`, `:164`), sold-out (`:166`), and requires exact payment `msg.value == (cost + MINT_FEE) * mintCount` (`:168`).
+2. **Supply model:** `totalMax == 0` ⇒ **unlimited**; otherwise **limited**. When limited, the reserve is clamped: `amountToReserve = min(mintCount, totalMax - total)` (`:172`), `claim.total` bumps, and any overpayment for un-fulfillable mints is **refunded** (`:180-183`).
+3. Reserved count is banked per wallet in `_mintDetailsPerWallet[...][msg.sender].reservedCount` (`:175`) and `SerendipityMintReserved` is emitted.
+4. **Randomization is entirely off-chain.** The signer computes which variation each reservation wins, then calls `deliverMints`, which for each `VariationMint` mints `startingTokenId + variationIndex - 1` and enforces the invariant `deliveredCount + amount <= reservedCount` (`:211`) before bumping `deliveredCount`.
+
+So the contract guarantees *conservation* (no wallet is delivered more than it reserved) but the *fairness of the draw* is a backend trust assumption.
+
+## Fee & membership handling
+
+- **`MINT_FEE` = 0.0005 ETH** is charged per mint on top of `cost` and retained by the contract (`:168`); `cost * amountToReserve` is forwarded to `claim.paymentReceiver` immediately (`:176-178`).
+- `cost` is `uint96`; an `erc20` field exists in `Claim` but `mintReserve` only handles **native ETH** payment — ERC-20 pricing is stored but not exercised in the reserve path here.
+- No merkle allowlist, delegation, or membership fee-waiver logic (contrast [[lazy-payable-claim]]).
+
+## Pitfalls
+
+- **Off-chain RNG.** No on-chain randomness source (no VRF, no blockhash). Trust the signer for fair draws.
+- The `erc20` claim field is set at init and **immutable** (`CannotChangePaymentToken` error exists) but `mintReserve` ignores it — do not assume ERC-20 gacha works via this path without a separate flow.
+- `updateClaim` cannot lower `totalMax` below `total` (`CannotLowerTotalMaxBeyondTotal`, `:111`) and cannot change `tokenVariations`.
+- Overpayment refund only triggers on the clamped-supply branch; exact-payment is otherwise required.
+
+## Open questions
+
+- Is ERC-20 payment handled by a different/newer variant, or dead config?
+- Delivery ordering/timeliness after reserve is a backend SLA, not enforced on-chain.
+
+See also: [[deck-claims]], [[frame-claims]], [[shared-libraries]].

--- a/docs/llm-wiki/concepts/lazy-payable-claim-v2.md
+++ b/docs/llm-wiki/concepts/lazy-payable-claim-v2.md
@@ -1,0 +1,67 @@
+---
+title: Lazy Payable Claim V2 (Updatable Fee)
+created: 2026-07-15
+updated: 2026-07-15
+type: concept
+package: manifold
+tags: [contract, abstract, interface, claim, erc721, erc1155, merkle, signature, delegation, membership, fee, version-v2, pitfall]
+sources: [manifold/contracts/lazyUpdatableFeeClaim/LazyPayableClaimV2.sol, manifold/contracts/lazyUpdatableFeeClaim/ERC721LazyPayableClaimV2.sol, manifold/contracts/lazyUpdatableFeeClaim/ERC1155LazyPayableClaimV2.sol, manifold/contracts/lazyUpdatableFeeClaim/ILazyPayableClaimV2.sol, manifold/contracts/lazyclaim/LazyPayableClaimCore.sol, manifold/contracts/lazyclaim/LazyPayableClaim.sol]
+confidence: high
+---
+
+# Lazy Payable Claim V2 (Updatable Fee)
+
+## What it is
+
+V2 of the [[lazy-payable-claim]] family. Same **shared singleton** model (one instance per chain, claims keyed by `(creatorContractAddress, instanceId)`), same `Claim` struct, same merkle/signature/delegation/membership mechanics — the **only** functional change is that the Manifold platform mint fee is now **mutable state** (settable by the extension owner) instead of a hardcoded `constant`, plus a global `active` kill-switch on new claim creation. See [[repo-overview]] and [[shared-libraries]].
+
+## Contract map
+
+- `manifold/contracts/lazyUpdatableFeeClaim/LazyPayableClaimV2.sol` — abstract: replaces `LazyPayableClaim.sol` from v1. Reuses the v1 `manifold/contracts/lazyclaim/LazyPayableClaimCore.sol` base directly (imported across directories) but redefines the fee layer.
+- `manifold/contracts/lazyUpdatableFeeClaim/ERC721LazyPayableClaimV2.sol` — concrete ERC721; inherits v1 `ERC721LazyPayableClaimCore` + `LazyPayableClaimV2`.
+- `manifold/contracts/lazyUpdatableFeeClaim/ERC1155LazyPayableClaimV2.sol` — concrete ERC1155 counterpart.
+- `manifold/contracts/lazyUpdatableFeeClaim/ILazyPayableClaimV2.sol` — extends `ILazyPayableClaim`, adds `Inactive` error + `setMintFees`/`setActive`.
+
+## The Claim struct
+
+**Unchanged from v1.** V2 imports the v1 interfaces and cores wholesale, so the ERC721 `Claim`/`ClaimParameters` (with `total`, `totalMax`, `walletMax`, `startDate`, `endDate`, `storageProtocol`, `contractVersion`, `identical`, `merkleRoot`, `location`, `cost`, `paymentReceiver`, `erc20`, `signingAddress`) and the ERC1155 `Claim` (with `tokenId`, no `contractVersion`/`identical`) are exactly as documented on [[lazy-payable-claim]]. No new claim fields were added.
+
+## External surface
+
+Identical `mint`/`mintBatch`/`mintProxy`/`mintSignature` signatures to v1 (declared via `ILazyPayableClaim` through `ILazyPayableClaimV2`), implemented in `ERC721LazyPayableClaimV2.sol` / `ERC1155LazyPayableClaimV2.sol`. Same admin surface (`initializeClaim`, `updateClaim`, `updateTokenURIParams`, `extendTokenURI`, `airdrop`) inherited from the v1 cores.
+
+**New owner-only functions** (`manifold/contracts/lazyUpdatableFeeClaim/ILazyPayableClaimV2.sol`, implemented in `LazyPayableClaimV2.sol`):
+
+```solidity
+function setMintFees(uint256 mintFee, uint256 mintFeeMerkle) external; // adminRequired
+function setActive(bool active) external;                              // adminRequired
+```
+
+## What changed vs v1
+
+| Aspect | v1 (`LazyPayableClaim.sol`) | V2 (`LazyPayableClaimV2.sol`) |
+| --- | --- | --- |
+| `MINT_FEE` / `MINT_FEE_MERKLE` | `public constant` (0.0005 / 0.00069 ETH) | mutable `public` storage `uint256`, initially `0` |
+| Fee setter | none | `setMintFees(uint256, uint256)` (`adminRequired`) |
+| New-claim gating | none | `bool public active = true` + `setActive`; `initializeClaim` reverts `Inactive()` when `active == false` (`ERC721LazyPayableClaimV2.sol:38`) |
+| Core / Claim struct / merkle / sig / delegation | — | reused unchanged from `manifold/contracts/lazyclaim/` |
+
+## Fee & membership handling
+
+`LazyPayableClaimV2._transferFunds` is byte-for-byte the same logic as v1's, except it reads the **mutable** `MINT_FEE` / `MINT_FEE_MERKLE` storage variables. Membership waiver is identical: fee skipped only when `MEMBERSHIP_ADDRESS` set, `allowMembership` true, and `IManifoldMembership.isActiveMember(msg.sender)` true (so `mintProxy`/`mintSignature` still never waive). Creator `cost` still forwards to `paymentReceiver`; platform fee accrues to the contract and is pulled with `withdraw`.
+
+## Merkle / signature / delegation mechanics
+
+Unchanged — all validation still runs through the shared v1 `manifold/contracts/lazyclaim/LazyPayableClaimCore.sol` (`_checkMerkleAndUpdate`, `_checkSignatureAndUpdate`, delegation-registry v1/v2 delegate checks). See [[lazy-payable-claim]] for details.
+
+## Pitfalls
+
+- **Fees default to ZERO on deployment.** `MINT_FEE` and `MINT_FEE_MERKLE` are uninitialized storage (`0`), not the v1 constants. The owner **must** call `setMintFees` after deploying or platform fees are silently uncollected.
+- **`setActive(false)` only blocks new `initializeClaim` calls** — it does NOT pause minting on already-initialized claims (`active` is only checked in `initializeClaim`).
+- Both new setters are `adminRequired` (extension owner), not `creatorAdminRequired` — they are global platform controls, not per-creator.
+- All v1 pitfalls still apply: signature claims require `mintSignature`; `walletMax`/`merkleRoot` mutually exclusive; `updateClaim` cannot change `erc20`.
+
+## Open questions
+
+- No USDC variant exists under `lazyUpdatableFeeClaim/` — USDC claims remain on the v1 fixed-fee `manifold/contracts/lazyclaim/*USDC.sol` contracts.
+- Whether existing v1 deployments were migrated to V2 or run in parallel is a deployment/ops question, not answerable from source.

--- a/docs/llm-wiki/concepts/lazy-payable-claim.md
+++ b/docs/llm-wiki/concepts/lazy-payable-claim.md
@@ -1,0 +1,94 @@
+---
+title: Lazy Payable Claim (v1)
+created: 2026-07-15
+updated: 2026-07-15
+type: concept
+package: manifold
+tags: [contract, abstract, interface, claim, erc721, erc1155, usdc, merkle, signature, delegation, membership, fee, pitfall]
+sources: [manifold/contracts/lazyclaim/LazyPayableClaimCore.sol, manifold/contracts/lazyclaim/LazyPayableClaim.sol, manifold/contracts/lazyclaim/ERC721LazyPayableClaim.sol, manifold/contracts/lazyclaim/ERC721LazyPayableClaimCore.sol, manifold/contracts/lazyclaim/ERC1155LazyPayableClaim.sol, manifold/contracts/lazyclaim/ERC1155LazyPayableClaimCore.sol, manifold/contracts/lazyclaim/LazyPayableClaimUSDC.sol, manifold/contracts/lazyclaim/ERC721LazyPayableClaimUSDC.sol, manifold/contracts/lazyclaim/ERC1155LazyPayableClaimUSDC.sol, manifold/contracts/lazyclaim/ILazyPayableClaim.sol, manifold/contracts/lazyclaim/ILazyPayableClaimCore.sol, manifold/contracts/lazyclaim/IERC721LazyPayableClaim.sol, manifold/contracts/lazyclaim/IERC1155LazyPayableClaim.sol, manifold/contracts/lazyclaim/ILazyPayableClaimUSDC.sol]
+confidence: high
+---
+
+# Lazy Payable Claim (v1)
+
+## What it is
+
+A **shared singleton extension** for selling "claim page" mints on Manifold Creator Core contracts. One instance is deployed per chain; every creator contract installs it as an extension and registers claims keyed by `(creatorContractAddress, instanceId)`. Tokens are minted lazily (on demand, buyer pays gas) rather than pre-minted. Supports public sales, merkle allowlists, and off-chain signature allowlists, with payment in ETH or an arbitrary ERC20 (plus dedicated USDC variants). See [[repo-overview]] and [[shared-libraries]]; the fee-updatable successor is [[lazy-payable-claim-v2]].
+
+## Contract map
+
+- `manifold/contracts/lazyclaim/LazyPayableClaimCore.sol` — abstract base: shared state (`_claims` live in the ERC721/ERC1155 core), merkle/signature/delegation validation helpers, `MEMBERSHIP_ADDRESS`, `creatorAdminRequired` modifier, delegation registry addresses.
+- `manifold/contracts/lazyclaim/LazyPayableClaim.sol` — abstract: ETH fee constants (`MINT_FEE`, `MINT_FEE_MERKLE`), `withdraw`, and the ETH `_transferFunds`.
+- `manifold/contracts/lazyclaim/ERC721LazyPayableClaimCore.sol` — abstract: ERC721 `Claim` storage, `initializeClaim`/`updateClaim`, `tokenURI`, `airdrop`, `_mintBatch`.
+- `manifold/contracts/lazyclaim/ERC721LazyPayableClaim.sol` — concrete ERC721: `mint`/`mintBatch`/`mintProxy`/`mintSignature`.
+- `manifold/contracts/lazyclaim/ERC1155LazyPayableClaimCore.sol` — abstract: ERC1155 `Claim` storage (has a `tokenId` field), init/update/tokenURI/airdrop, `_mintClaim`.
+- `manifold/contracts/lazyclaim/ERC1155LazyPayableClaim.sol` — concrete ERC1155 mint functions.
+- `manifold/contracts/lazyclaim/LazyPayableClaimUSDC.sol` — abstract: USDC-denominated fees + `_transferFunds` that pulls USDC via `transferFrom`.
+- `manifold/contracts/lazyclaim/ERC721LazyPayableClaimUSDC.sol` / `ERC1155LazyPayableClaimUSDC.sol` — concrete USDC variants; `mint*` are **non-payable** and force `claim.erc20 == USDC_ADDRESS`.
+- Interfaces: `ILazyPayableClaimCore.sol` (errors, `StorageProtocol` enum, events, view helpers), `ILazyPayableClaim.sol` (the four `mint*` signatures), `IERC721LazyPayableClaim.sol` / `IERC1155LazyPayableClaim.sol` (`ClaimParameters` + `Claim` structs), `ILazyPayableClaimUSDC.sol` (adds `InvalidUSDCAddress`).
+
+## The Claim struct
+
+ERC721 `Claim` (`manifold/contracts/lazyclaim/IERC721LazyPayableClaim.sol`):
+
+```solidity
+struct Claim {
+    uint32 total;            // minted so far
+    uint32 totalMax;         // 0 = unlimited
+    uint32 walletMax;        // 0 = unlimited (non-merkle only)
+    uint48 startDate;
+    uint48 endDate;          // 0 = no end
+    StorageProtocol storageProtocol; // INVALID/NONE/ARWEAVE/IPFS/ADDRESS
+    uint8 contractVersion;
+    bool identical;          // if false, append /mintOrder to URI
+    bytes32 merkleRoot;      // "" = no allowlist
+    string location;
+    uint256 cost;            // per-mint price (excludes platform fee)
+    address payable paymentReceiver;
+    address erc20;           // ADDRESS_ZERO = ETH
+    address signingAddress;  // set => signature minting required
+}
+```
+
+The ERC1155 `Claim` (`manifold/contracts/lazyclaim/IERC1155LazyPayableClaim.sol`) is the same minus `contractVersion`/`identical` and **adds `uint256 tokenId`** (the shared 1155 token id). `ClaimParameters` is the init/update payload (same fields minus `total`, `contractVersion`, `tokenId`).
+
+## External surface
+
+Callers hit the four mint functions declared in `manifold/contracts/lazyclaim/ILazyPayableClaim.sol`, implemented in `ERC721LazyPayableClaim.sol` / `ERC1155LazyPayableClaim.sol`:
+
+```solidity
+function mint(address creatorContractAddress, uint256 instanceId, uint32 mintIndex,
+    bytes32[] calldata merkleProof, address mintFor) external payable;
+function mintBatch(address creatorContractAddress, uint256 instanceId, uint16 mintCount,
+    uint32[] calldata mintIndices, bytes32[][] calldata merkleProofs, address mintFor) external payable;
+function mintProxy(address creatorContractAddress, uint256 instanceId, uint16 mintCount,
+    uint32[] calldata mintIndices, bytes32[][] calldata merkleProofs, address mintFor) external payable;
+function mintSignature(address creatorContractAddress, uint256 instanceId, uint16 mintCount,
+    bytes calldata signature, bytes32 message, bytes32 nonce, address mintFor, uint256 expiration) external payable;
+```
+
+Admin surface (`manifold/contracts/lazyclaim/ERC721LazyPayableClaimCore.sol`, guarded by `creatorAdminRequired`): `initializeClaim`, `updateClaim`, `updateTokenURIParams`, `extendTokenURI`, `airdrop`. Views: `getClaim`, `getClaimForToken`, `checkMintIndex(es)`, `getTotalMints`. Owner-only: `setMembershipAddress`, `withdraw`. USDC variants (`ERC721LazyPayableClaimUSDC.sol`) declare the same four `mint*` but **without `payable`** (fee & cost both flow in USDC via `transferFrom`).
+
+## Fee & membership handling
+
+Platform fee is a flat constant added on top of `cost`, in `LazyPayableClaim._transferFunds` (`manifold/contracts/lazyclaim/LazyPayableClaim.sol`): `MINT_FEE = 0.0005 ETH`, `MINT_FEE_MERKLE = 0.00069 ETH` — merkle mints pay the higher fee. USDC variant uses `MINT_FEE = 1_000000` / `MINT_FEE_MERKLE = 1_330000` (6-decimal USDC). The fee is **waived** only when `MEMBERSHIP_ADDRESS` is set, `allowMembership` is true, and `IManifoldMembership(MEMBERSHIP_ADDRESS).isActiveMember(msg.sender)` returns true. `mintProxy`/`mintSignature` pass `allowMembership = false`, so the fee is never waived there. `cost` (creator revenue) is forwarded to `paymentReceiver`; the platform fee accrues to the extension contract and is pulled out with `withdraw`.
+
+## Merkle / signature / delegation mechanics
+
+- **Merkle** (`_checkMerkleAndUpdate` in `LazyPayableClaimCore.sol`): leaf = `keccak256(abi.encodePacked(mintFor, mintIndex))`. Consumed indices are tracked as a bitmask (`_claimMintIndices`, `mintIndex >> 8` bucket, `1 << (mintIndex & 0xFF)`), so each index is single-use.
+- **Delegation**: if `mintFor != msg.sender` on a merkle mint, the caller must be a delegate of `mintFor` per `IDelegationRegistryV2.checkDelegateForContract` OR the legacy `IDelegationRegistry` (see [[shared-libraries]]).
+- **Signature** (`_checkSignatureAndUpdate`): message = `keccak256(abi.encodePacked(creatorContractAddress, instanceId, nonce, mintFor, expiration, mintCount))`, recovered via ECDSA against `claim.signingAddress`; `nonce` is single-use (`_usedMessages`) and `expiration` is enforced.
+
+## Pitfalls
+
+- **A `signingAddress` claim can ONLY be minted via `mintSignature`.** `mint`/`mintBatch`/`mintProxy` all revert `MustUseSignatureMinting` when `signingAddress != address(0)` (`ERC721LazyPayableClaim.sol:40`).
+- **`walletMax` and `merkleRoot` are mutually exclusive** — `initializeClaim` rejects both being set. `walletMax` limits only apply to non-merkle claims.
+- **`updateClaim` cannot change the payment token** — `erc20` mismatch reverts `CannotChangePaymentToken` (`ERC721LazyPayableClaimCore.sol:128`).
+- **ETH fees are hardcoded constants** in v1 — the whole reason [[lazy-payable-claim-v2]] exists is to make them settable.
+- **`mintProxy`/`mintSignature` never waive the platform fee** (membership ignored).
+- ERC721 `totalMax` is also bounded by `MAX_UINT_24`; overflow reverts `TooManyRequested`.
+
+## Open questions
+
+- Full `ERC1155LazyPayableClaimCore._mintClaim` / `initializeClaim` body (tokenId assignment via `mintExtensionNew`) not fully transcribed here — a reference dump of the 1155 core is warranted.
+- `IERC721LazyPayableClaimMetadata` / `IERC1155LazyPayableClaimMetadata` (the `StorageProtocol.ADDRESS` external URI resolver) are referenced but not documented on this page.

--- a/docs/llm-wiki/concepts/lazywhitelist-and-fonts.md
+++ b/docs/llm-wiki/concepts/lazywhitelist-and-fonts.md
@@ -1,0 +1,69 @@
+---
+title: LazyWhitelist & Fonts Packages
+created: 2026-07-15
+updated: 2026-07-15
+type: concept
+package: lazywhitelist
+tags: [contract, abstract, interface, whitelist, merkle, erc721, pitfall]
+sources: [lazywhitelist/contracts/ERC721LazyMintWhitelistBase.sol, lazywhitelist/contracts/ERC721LazyMintWhitelistImplementation.sol, lazywhitelist/contracts/ERC721LazyMintWhitelistTemplate.sol, lazywhitelist/contracts/IERC721LazyMintWhitelist.sol, fonts/contracts/IFontWOFF.sol]
+confidence: high
+---
+
+# LazyWhitelist & Fonts Packages
+
+Two small, unrelated packages. **LazyWhitelist** is a merkle-gated paid lazy-mint extension (clone pattern). **Fonts** is a single interface for on-chain WOFF font storage. See [[repo-overview]], [[shared-libraries]].
+
+---
+
+## Section 1 — LazyWhitelist (merkle-gated lazy mint)
+
+### What it is
+An ERC721 extension letting whitelisted addresses pay a fixed price to lazy-mint a token from a Manifold creator contract, with admin "premint" (gifting) and a sequential edition-numbered `tokenURI`. Allowlist membership is proven with a merkle proof. Ships as `Base` (abstract) + `Implementation` (clone target) + `Template` (EIP-1967 minimal proxy) — the same clone shape as [[lazy-payable-claim]] and the edition package.
+
+### Contract map
+- `lazywhitelist/contracts/ERC721LazyMintWhitelistBase.sol` — abstract core. Holds `merkleRoot`, `MINT_PRICE = 0.1 ether`, `MAX_MINTS = 50`, `_tokensMinted`, per-token `_tokenEdition`. Implements `ICreatorExtensionTokenURI` and the merkle check.
+- `lazywhitelist/contracts/ERC721LazyMintWhitelistImplementation.sol` — concrete clone target: `AdminControlUpgradeable` + `initializer`, exposes the public admin/mint surface.
+- `lazywhitelist/contracts/ERC721LazyMintWhitelistTemplate.sol` — `Proxy` writing implementation into `_IMPLEMENTATION_SLOT` and delegatecalling `initialize(address,string)` in its constructor.
+- `lazywhitelist/contracts/IERC721LazyMintWhitelist.sol` — interface.
+
+### Key state / interface
+- `bytes32 merkleRoot`, `uint MINT_PRICE`, `uint MAX_MINTS`, `uint256 public _tokensMinted`, `mapping(uint256 => uint256) _tokenEdition`, `string _tokenPrefix`.
+- `onAllowList(address claimer, bytes32[] proof)` — `MerkleProof.verify(proof, merkleRoot, keccak256(abi.encodePacked(claimer)))`.
+
+### External surface (traced)
+`IERC721LazyMintWhitelist`: `premint(address[] to)`, `mint(bytes32[] merkleProof) payable`, `setAllowList(bytes32 _merkleRoot)`, `setTokenURIPrefix(string prefix)`, `withdraw(address _to, uint amount)`.
+`Base` public: `onAllowList(address,bytes32[])`, `tokenURI(address,uint256)`, `_tokensMinted`.
+`Implementation`: `initialize(address creator, string prefix)` (initializer); `premint`/`setAllowList`/`setTokenURIPrefix`/`withdraw` are `adminRequired`; `mint` is public `payable`.
+
+### Distinctive mechanic — clone/template pattern
+`ERC721LazyMintWhitelistTemplate` (an OZ `Proxy`) stores the implementation in the EIP-1967 slot `0x360894...382bbc` and `Address.functionDelegateCall`s `initialize(address,string)` at construction, producing a cheap per-creator clone. `mint` checks, in order: `_tokensMinted < MAX_MINTS`, `MINT_PRICE == msg.value`, and `onAllowList(msg.sender, proof)`, then mints via `IERC721CreatorCore.mintExtension` and records a 1-based `_tokenEdition`. `tokenURI = prefix + edition`.
+
+### Pitfalls
+- **`MINT_PRICE` and `MAX_MINTS` are hard-coded** (`0.1 ether` / `50`) with `// to be changed` comments and **no setter** — there is no way to change price/cap after deploy; treat this package as example/starter code, not production-hardened.
+- `_premint` both mints gifts *and* bumps `MAX_MINTS += to.length`, so gifting quietly raises the public cap.
+- `mint` requires exact `msg.value == MINT_PRICE` (no over/under-pay).
+- Merkle leaf is `keccak256(abi.encodePacked(claimer))` (address only) — the allowlist tree must be built the same way, and it does not bind quantity.
+- `Base.supportsInterface` only reports `ICreatorExtensionTokenURI` (the `Implementation` OR-combines admin + its own interface).
+
+---
+
+## Section 2 — Fonts (on-chain WOFF interface)
+
+### What it is
+A single interface, `IFontWOFF`, describing a contract that returns a WOFF font as a string — intended so fully on-chain art (e.g. SVG generators) can pull font data from a dedicated storage contract. This package is **interface-only**; no implementation ships here.
+
+### Contract map
+- `fonts/contracts/IFontWOFF.sol` — `interface IFontWOFF { function woff() external view returns(string memory); }`.
+
+### External surface (traced)
+- `woff() external view returns(string memory)` — the entire surface.
+
+### Pitfalls / notes
+- No concrete contract in this package — consumers must supply their own storage implementation returning `woff()`.
+- Returning a full WOFF as a `string` implies large calldata/return payloads; only practical for on-chain rendering read paths (view calls), not on-chain writes per render.
+
+## Open questions
+- Is there a deployed `IFontWOFF` implementation elsewhere in the monorepo or an external repo that on-chain SVG extensions consume?
+- Was LazyWhitelist ever deployed in production given the hard-coded, unchangeable price/cap, or is it purely a reference implementation?
+
+See also: [[repo-overview]], [[lazy-payable-claim]], [[shared-libraries]].

--- a/docs/llm-wiki/concepts/metadata-frozen.md
+++ b/docs/llm-wiki/concepts/metadata-frozen.md
@@ -1,0 +1,87 @@
+---
+title: Frozen Metadata Extensions
+created: 2026-07-15
+updated: 2026-07-15
+type: concept
+package: manifold
+tags: [contract, interface, metadata, erc721, erc1155, admin, operator-filter, pitfall]
+sources: [manifold/contracts/metadata/ERC721FrozenMetadata.sol, manifold/contracts/metadata/ERC1155FrozenMetadata.sol, manifold/contracts/metadata/ERC721FrozenMetadataNoFilterer.sol, manifold/contracts/metadata/ERC1155FrozenMetadataNoFilterer.sol, manifold/contracts/metadata/IERC721FrozenMetadata.sol, manifold/contracts/metadata/IERC1155FrozenMetadata.sol]
+confidence: high
+---
+
+# Frozen Metadata Extensions
+
+## What it is
+
+A pair of shared extensions (ERC721 + ERC1155) that mint tokens whose `tokenURI`
+is a **fully-qualified, immutable URI supplied at mint time**. The extension
+exposes only mint functions — there is no `setTokenURI` on the contract — so once
+a token is minted through it, that extension can never rewrite the URI. This is
+the "frozen metadata" guarantee. See [[repo-overview]] for where this sits among
+the shared extensions.
+
+## Contract map
+
+| File | Role |
+|------|------|
+| `metadata/IERC721FrozenMetadata.sol` | Interface — declares `mintToken` |
+| `metadata/IERC1155FrozenMetadata.sol` | Interface — declares `mintTokenNew`, `mintTokenExisting` |
+| `metadata/ERC721FrozenMetadata.sol` | ERC721 implementation |
+| `metadata/ERC1155FrozenMetadata.sol` | ERC1155 implementation |
+| `metadata/ERC721FrozenMetadataNoFilterer.sol` | ERC721 impl + `ERC721NoFilterer` mix-in |
+| `metadata/ERC1155FrozenMetadataNoFilterer.sol` | ERC1155 impl + `ERC1155NoFilterer` mix-in |
+
+## External surface (traced)
+
+**ERC721** (`metadata/ERC721FrozenMetadata.sol`):
+- `mintToken(address creator, address recipient, string calldata tokenURI) external returns(uint256)` — reverts `"Cannot mint blank string"` if `tokenURI` is empty, then calls `IERC721CreatorCore(creator).mintExtension(recipient, tokenURI)`.
+- `supportsInterface(bytes4) → bool` — true only for `type(IERC721FrozenMetadata).interfaceId`.
+
+**ERC1155** (`metadata/ERC1155FrozenMetadata.sol`):
+- `mintTokenNew(address creator, address[] to, uint256[] amounts, string[] uris) external returns(uint256[])` — loops all `uris`, reverts `"Cannot mint blank string"` on any empty entry, then `mintExtensionNew(to, amounts, uris)`.
+- `mintTokenExisting(address creator, address[] to, uint256[] tokenIds, uint256[] amounts) external` — `mintExtensionExisting(...)`; adds supply to already-minted tokens (no new URI).
+- `supportsInterface(bytes4) → bool` — true only for `type(IERC1155FrozenMetadata).interfaceId`.
+
+All mint functions are gated by the `creatorAdminRequired(creator)` modifier:
+`require(IAdminControl(creator).isAdmin(msg.sender), "Must be owner or admin of creator contract")`.
+
+## Enforcement mechanism
+
+Immutability is **structural, not a runtime hook**. The extension delegates
+minting to the creator core's `mintExtension*` functions, which permanently
+associate the passed URI with the token. Because the extension exposes no
+URI-mutation entrypoint, no admin path exists to change it later *through this
+extension*. Contrast with [[soulbound]], which keeps `setTokenURI*` methods.
+
+## Filterer vs no-filterer distinction
+
+The base contracts do **not** implement `IERC*CreatorExtensionApproveTransfer`,
+so a creator using them applies no operator gating from this extension. The
+`*NoFilterer` variants additionally inherit
+`operatorfilterer/nofilterer/ERC721NoFilterer.sol` /
+`ERC1155NoFilterer.sol`, which implement `approveTransfer(...) → true` (always
+allow) and advertise the ApproveTransfer interface. This lets a creator that has
+approve-transfer checking enabled install a frozen-metadata extension that
+**explicitly opts out** of any marketplace filtering. See [[operator-filterer]].
+
+The only override in the `*NoFilterer` contracts is `supportsInterface`, which
+ORs both parents so both the frozen-metadata and the no-filterer interfaces are
+advertised.
+
+## Pitfalls
+
+- `mintTokenExisting` (ERC1155) does **not** validate any URI — it only adds
+  supply to existing tokens. The "no blank string" guard is on `mintTokenNew`
+  only.
+- The ERC721 `supportsInterface` in the base contract advertises *only* the
+  frozen-metadata interface (not `IERC165` itself) — a strict `IERC165`
+  probe returns false. The `*NoFilterer` variant fixes this by ORing in the
+  no-filterer interface set.
+- "Frozen" is a property of *this extension's* surface. It does not stop a
+  different admin extension on the same creator from rewriting the URI.
+
+## Open questions
+
+- Does `IERC721CreatorCore.mintExtension` itself reject later URI edits, or is
+  immutability purely a function of no extension exposing an editor? (Requires
+  reading `creator-core-solidity`; see [[shared-libraries]].)

--- a/docs/llm-wiki/concepts/operator-filterer.md
+++ b/docs/llm-wiki/concepts/operator-filterer.md
@@ -1,0 +1,114 @@
+---
+title: Operator Filterer Extensions
+created: 2026-07-15
+updated: 2026-07-15
+type: concept
+package: manifold
+tags: [contract, abstract, operator-filter, erc721, erc1155, admin, pitfall]
+sources: [manifold/contracts/operatorfilterer/CreatorOperatorFilterer.sol, manifold/contracts/operatorfilterer/OperatorFilterer.sol, manifold/contracts/operatorfilterer/nofilterer/ERC721NoFilterer.sol, manifold/contracts/operatorfilterer/nofilterer/ERC1155NoFilterer.sol]
+confidence: high
+---
+
+# Operator Filterer Extensions
+
+## What it is
+
+Shared extensions that plug into the creator core's per-transfer
+`approveTransfer` hook to **block transfers initiated by disallowed marketplace
+operators** — Manifold's take on OpenSea's operator-filter-registry royalty
+enforcement. Two enforcement models ship: a registry-backed subscription model
+(`OperatorFilterer`) and a creator-configurable on-contract blocklist
+(`CreatorOperatorFilterer`). A third, no-op "NoFilterer" family exists to
+explicitly opt out. See [[repo-overview]].
+
+## Contract map
+
+| File | Role |
+|------|------|
+| `operatorfilterer/OperatorFilterer.sol` | Registry-subscription filterer; queries external `IOperatorFilterRegistry` |
+| `operatorfilterer/CreatorOperatorFilterer.sol` | Creator-controlled on-chain blocklist (addresses + code hashes) |
+| `operatorfilterer/nofilterer/ERC721NoFilterer.sol` | `abstract` — ERC721 approveTransfer that always returns `true` |
+| `operatorfilterer/nofilterer/ERC1155NoFilterer.sol` | `abstract` — ERC1155 approveTransfer that always returns `true` |
+
+## External surface (traced)
+
+Both filterers implement the dual ERC721/ERC1155 `approveTransfer` hooks and
+advertise both `IERC721CreatorExtensionApproveTransfer` /
+`IERC1155CreatorExtensionApproveTransfer` in `supportsInterface`:
+
+- `approveTransfer(address operator, address from, address, uint256[] , uint256[]) → bool` (ERC1155)
+- `approveTransfer(address operator, address from, address, uint256) → bool` (ERC721)
+
+Both delegate to internal `isOperatorAllowed(operator, from)`.
+
+**`OperatorFilterer.sol`** additionally has:
+- immutables `OPERATOR_FILTER_REGISTRY`, `SUBSCRIPTION`
+- `constructor(address operatorFilterRegistry, address subscription)` which calls `registerAndSubscribe(address(this), SUBSCRIPTION)` on the registry.
+
+**`CreatorOperatorFilterer.sol`** additionally has admin-gated config
+(`creatorAdminRequired`: `require(IAdminControl(creator).isAdmin(msg.sender), "Wallet is not an admin")`):
+- `configureBlockedOperators(address creator, address[] operators, bool[] blocked)`
+- `configureBlockedOperatorHashes(address creator, bytes32[] hashes, bool[] blocked)`
+- `configureBlockedOperatorsAndHashes(...)` — calls both
+- views `getBlockedOperators(creator)`, `getBlockedOperatorHashes(creator)`
+- events `OperatorUpdated`, `CodeHashUpdated`; errors `OperatorNotAllowed`, `CodeHashFiltered`
+- storage: `EnumerableSet.AddressSet` per creator + `EnumerableSet.Bytes32Set` of blocked code hashes.
+
+## Enforcement mechanism
+
+Both models veto in `isOperatorAllowed`, called from the `approveTransfer` hook
+the creator core invokes on each transfer. The `from != operator` guard means a
+holder moving their **own** token is never blocked; only third-party operators
+are filtered.
+
+**Registry model** (`operatorfilterer/OperatorFilterer.sol` lines 52–59):
+```
+if (from != operator) {
+  if (!IOperatorFilterRegistry(OPERATOR_FILTER_REGISTRY)
+        .isOperatorAllowed(address(this), operator))
+      revert OperatorNotAllowed(operator);
+}
+```
+The blocklist is external and shared via the subscription set in the constructor.
+
+**Creator model** (`operatorfilterer/CreatorOperatorFilterer.sol` lines 130–144):
+checks the per-creator (`msg.sender`) `EnumerableSet` of blocked operators; if
+the operator has code, also checks its `codehash` against the filtered-hash set,
+reverting `OperatorNotAllowed` / `CodeHashFiltered`. Enforcement data lives
+**on this contract**, keyed by the calling creator — no external registry.
+
+Note: the registry model **reverts** on a blocked operator; the creator model
+also reverts. Neither returns `false` in the blocked path — they throw custom
+errors, which propagate up through the creator core transfer.
+
+## Filterer vs no-filterer distinction
+
+`nofilterer/ERC721NoFilterer.sol` and `ERC1155NoFilterer.sol` are `abstract`
+mix-ins whose `approveTransfer(...) external pure returns (bool)` **always
+returns `true`** and which advertise the ApproveTransfer interface. They are
+inherited by opt-out extension variants (e.g. the frozen-metadata `*NoFilterer`
+builds in [[metadata-frozen]]) so a creator with approve-transfer checking on
+can install an extension that performs **no** marketplace filtering. Contrast
+with [[soulbound]], which uses the same hook to block by transfer semantics
+rather than by operator.
+
+## Pitfalls
+
+- **`msg.sender` is the creator contract.** `CreatorOperatorFilterer` keys all
+  blocklists by `msg.sender` (the calling creator), so blocklists are per-creator
+  even though the extension is a single shared deployment.
+- **Registry availability.** `OperatorFilterer` depends on an external
+  `IOperatorFilterRegistry`; if that registry is deprecated/removed on-chain, its
+  `isOperatorAllowed` behavior — and thus transfers — can change outside the
+  creator's control. The creator model avoids this dependency.
+- **Own-transfer bypass is intentional** (`from == operator` skips checks) — do
+  not treat this as a soulbound guarantee; use [[soulbound]] for that.
+- Blocked paths revert (custom errors), they do not silently return `false`;
+  callers integrating these must expect reverts, not boolean vetoes.
+
+## Open questions
+
+- Which registry/subscription addresses are wired at deployment for
+  `OperatorFilterer` (constructor args) — see deploy scripts / [[shared-libraries]].
+- Whether a creator can hold both an operator filterer and soulbound on the same
+  approve-transfer slot simultaneously, or only one at a time.

--- a/docs/llm-wiki/concepts/physical-claim.md
+++ b/docs/llm-wiki/concepts/physical-claim.md
@@ -1,0 +1,81 @@
+---
+title: Physical Claim
+created: 2026-07-15
+updated: 2026-07-15
+type: concept
+package: manifold
+tags: [contract, interface, physical, burn-redeem, erc721, erc1155, signature, membership, fee, struct, pitfall]
+sources: [manifold/contracts/physicalclaim/PhysicalClaim.sol, manifold/contracts/physicalclaim/IPhysicalClaim.sol, manifold/contracts/physicalclaim/Interfaces.sol]
+confidence: high
+---
+
+# Physical Claim
+
+## What it is
+
+A **burn-to-redeem-a-physical-item** extension. The redeemer burns one or more NFTs, and — instead of minting a new on-chain token — the contract simply emits a `Redeem` event and increments counters. The physical fulfillment happens off-chain; the event + signed submission are the on-chain receipt. Every redemption is authorized by an **off-chain ECDSA signature** over the full submission, so limits, price, and eligibility are server-controlled rather than stored per-instance. Related to `[[burn-redeem]]` but the "output" is a real-world good, not an NFT.
+
+## Contract map
+
+| File (relative to `packages/`) | Role |
+|---|---|
+| `manifold/contracts/physicalclaim/PhysicalClaim.sol` | The contract: `burnRedeem` (single + batch), token-receiver hooks, burn dispatch, signature/nonce/limit validation, fee logic. Extends `AdminControl` + `ReentrancyGuard`. |
+| `manifold/contracts/physicalclaim/IPhysicalClaim.sol` | Interface: `BurnSubmission`/`BurnToken` structs, `TokenSpec`/`BurnSpec` enums, errors, `Redeem` event. |
+| `manifold/contracts/physicalclaim/Interfaces.sol` | Minimal burn interfaces: `Burnable721`, `OZBurnable1155`, `Manifold1155`. |
+
+## Key structs & enums (`physicalclaim/IPhysicalClaim.sol`)
+
+- `BurnSubmission { bytes signature; bytes32 message; uint256 instanceId; BurnToken[] burnTokens; uint8 variation; uint64 variationLimit; uint64 totalLimit; address erc20; uint256 price; address payable fundsRecipient; uint160 expiration; bytes32 nonce; }`
+- `BurnToken { address contractAddress; uint256 tokenId; TokenSpec tokenSpec; BurnSpec burnSpec; uint72 amount; }`
+- `enum TokenSpec { INVALID, ERC721, ERC1155, ERC721_NO_BURN }`
+- `enum BurnSpec { INVALID, NONE, MANIFOLD, OPENZEPPELIN }`
+
+## External surface
+
+`physicalclaim/PhysicalClaim.sol`:
+- `burnRedeem(BurnSubmission submission)` — `payable`, `nonReentrant`
+- `burnRedeem(BurnSubmission[] submissions)` — `payable`, `nonReentrant`; skips sold-out entries and refunds unused `msg.value`
+- `onERC721Received / onERC1155Received / onERC1155BatchReceived` — receiver-hook burn path (submission ABI-encoded in `data`)
+- `withdraw(address payable, uint256)` · `setMembershipAddress(address)` · `updateSigner(address)`
+- `recover(address tokenAddress, uint256 tokenId, address destination)` — rescue a mistakenly-sent ERC721
+- `getVariationCounts(uint256 instanceId, uint8[] variations) → uint64[]`
+- `getTotalCount(uint256 instanceId) → uint64`
+- `constructor(address initialOwner, address signingAddress)`
+
+## Distinctive mechanic
+
+**Signature over the whole submission.** `_validateSubmission` recomputes `keccak256(abi.encode(instanceId, burnTokens, variation, variationLimit, totalLimit, erc20, price, fundsRecipient, expiration, nonce))`, requires `submission.message` to equal it, requires `message.recover(signature) == _signingAddress`, checks `block.timestamp <= expiration`, and consumes the per-instance `nonce`. All economic terms are signed — the contract stores no per-instance config, only counters. There is **no `initialize` step**; the signer is the single source of truth (one global `_signingAddress`, updatable via `updateSigner`).
+
+**Four burn modes** (`_burn`, dispatched by `TokenSpec` × `BurnSpec`):
+- `ERC1155` → `MANIFOLD` (`Manifold1155.burn`), `OPENZEPPELIN` (`OZBurnable1155.burn`), or `NONE` (transfer to `0xdEaD`).
+- `ERC721` → `MANIFOLD`/`OPENZEPPELIN` (`Burnable721.burn` after owner check), or `NONE` (transfer to `0xdEaD`).
+- `ERC721_NO_BURN` → **not burned at all**: token is verified as owned and marked in `_usedTokens[instanceId][contract][tokenId]` so it can't be reused. Useful for tokens that must survive.
+
+**Two entry paths:** direct `burnRedeem` (approve-then-call, supports ETH/ERC20 price + fee), or `safeTransferFrom` into the contract with the submission in `data` — but the transfer path only works when there is no ETH price and the sender is an active member (`_validateCanReceive`), since a bare transfer carries no payment.
+
+**Variation & total caps** are enforced against the *signed* `variationLimit`/`totalLimit` via `_isVariationAvailable`; batch calls silently skip unavailable variations rather than reverting the whole batch.
+
+## Fee / membership handling
+
+`BURN_FEE = 690000000000000` (single-token) and `MULTI_BURN_FEE = 990000000000000` for submissions with >1 burn token. In `_redeem`, non-members pay `price (if native) + fee`; active members (`IManifoldMembership.isActiveMember`) pay neither the fee nor need it bundled. Native price is forwarded to `fundsRecipient`; ERC20 price uses `transferFrom(redeemer, fundsRecipient, price)`. Admin sweeps accrued fees via `withdraw`.
+
+## Pitfalls
+
+- **No on-chain instance config** — `instanceId` is just a namespace for nonces/counters/used-tokens. A bad or malicious signer can authorize arbitrary terms; security rests entirely on `_signingAddress`.
+- Nonces are unique **per instanceId**, not global; the same `nonce` value can be legitimately reused across different instances.
+- `ERC721_NO_BURN` tokens are consumed logically (marked used) but stay in the owner's wallet — double-submitting the same token reverts `InvalidToken`.
+- Receiver-hook path rejects any submission with a native `price != 0` or a non-member sender (`_validateCanReceive`), and requires exactly one `burnToken` for the single-token hooks.
+- Batch `burnRedeem` uses a running `msgValue` and refunds the remainder; if a submission is skipped as sold-out, its funds are not consumed. Under/over-payment across the batch is reconciled at the end.
+- ERC721 `MANIFOLD`/`OPENZEPPELIN` burns verify `ownerOf == from` because 721 `burn(tokenId)` has no `from` param — a spoofed owner reverts `TransferFailure`.
+- `recover` only handles ERC721; ERC1155 sent without the burn `data` cannot be rescued the same way.
+
+## Open questions
+
+- Is there an ERC1155/ERC721 *output* variant elsewhere, or is physical-only fulfillment the whole point of this family?
+- `expiration` is `uint160` in the struct but compared against `block.timestamp` — the wide type seems deliberate; is it a packing artifact?
+
+## See also
+
+- `[[repo-overview]]` — where physical claim sits among extensions.
+- `[[burn-redeem]]` — the NFT-output sibling of this burn mechanic.
+- `[[shared-libraries]]` — `IManifoldMembership` fee-waiver plumbing.

--- a/docs/llm-wiki/concepts/redeem-package.md
+++ b/docs/llm-wiki/concepts/redeem-package.md
@@ -1,0 +1,53 @@
+---
+title: Redeem Package (Legacy Burn-Redeem)
+created: 2026-07-15
+updated: 2026-07-15
+type: concept
+package: redeem
+tags: [contract, abstract, interface, burn-redeem, erc721, erc1155, struct, pitfall]
+sources: [redeem/contracts/RedeemBase.sol, redeem/contracts/IRedeemBase.sol, redeem/contracts/RedeemSetBase.sol, redeem/contracts/ERC721/ERC721RedeemBase.sol, redeem/contracts/ERC721/ERC721BurnRedeem.sol, redeem/contracts/ERC721/IERC721BurnRedeem.sol, redeem/contracts/ERC721/ERC721BurnRedeemSet.sol, redeem/contracts/ERC1155/ERC1155RedeemBase.sol, redeem/contracts/ERC1155/ERC1155ClaimRedeem.sol]
+confidence: high
+---
+
+# Redeem Package (Legacy Burn-Redeem)
+
+## What it is
+The **original** burn-redeem system: users burn one or more approved NFTs and receive a freshly lazy-minted reward NFT from a Manifold creator contract. This package **predates and is superseded by** [[burn-redeem]] (manifold/burnredeem). Contracts here send burned tokens to `address(0xdEaD)` (a pseudo-burn) rather than calling a native burn, and configuration is stored per-extension rather than in a shared shared-storage manager. Prefer the newer implementation for anything current; this page documents the legacy model. See [[repo-overview]].
+
+## Contract map
+- `redeem/contracts/RedeemBase.sol` — abstract base (`AdminControl`). Manages the *approved redeemables* registry: whole contracts, specific tokens, and token ranges.
+- `redeem/contracts/IRedeemBase.sol` — interface; defines `TokenRange{min,max}` struct + admin/getter surface.
+- `redeem/contracts/RedeemSetBase.sol` — abstract base for **set** redemptions (must supply a full set of tokens to redeem one reward). Holds `RedemptionItem[]`.
+- `redeem/contracts/ERC721/ERC721RedeemBase.sol` — abstract; adds redemption accounting (rate/max/count, mint numbering) and mints via `IERC721CreatorCore.mintExtension`.
+- `redeem/contracts/ERC721/ERC721BurnRedeem.sol` — concrete burn-redeem (contract named `ERC721Burn`). Accepts NFTs via explicit call or `onERC721Received`/`onERC1155Received`.
+- `redeem/contracts/ERC721/ERC721BurnRedeemSet.sol` — concrete set variant; requires a complete set before minting.
+- `redeem/contracts/ERC1155/ERC1155RedeemBase.sol` — abstract ERC1155 redeem base.
+- `redeem/contracts/ERC1155/ERC1155ClaimRedeem.sol` — abstract; claim (not burn) an ERC1155 reward, tracking `_claimedERC721` to prevent double-claims.
+
+## Key structs / interfaces
+- `IRedeemBase.TokenRange { uint256 min; uint256 max; }` — inclusive redeemable range.
+- `RedeemBase` storage: `_approvedContracts`, `_approvedTokens` (per-contract `UintSet`), `_approvedTokenRange` (per-contract `TokenRange[]`).
+- `ERC721RedeemBase`: `_redemptionRate` (immutable, NFTs burned per reward), `_redemptionMax`, `_redemptionCount`, `_mintNumbers`, `_mintedTokens`.
+- `RedemptionItem` (from `IRedeemSetBase`) — used by set variants; carries `tokenAddress`, `minTokenId`, `maxTokenId`.
+
+## External surface (traced)
+`RedeemBase`: `updateApprovedContracts(address[],bool[])`, `getApprovedContracts()`, `updateApprovedTokens(address,uint256[],bool[])`, `getApprovedTokens()`, `updateApprovedTokenRanges(address,uint256[],uint256[])`, `getApprovedTokenRanges()`, `redeemable(address,uint256)` — all admin-gated writes via `adminRequired`.
+`ERC721RedeemBase`: `redemptionMax()`, `redemptionRate()`, `redemptionRemaining()`, `mintNumber(uint256)`, `mintedTokens()`.
+`ERC721Burn` (BurnRedeem): `setERC721Recoverable(address,uint256,address)`, `recoverERC721(address,uint256)`, `redeemERC721(address[],uint256[])`, plus `onERC721Received`/`onERC1155Received`/`onERC1155BatchReceived`.
+`ERC1155ClaimRedeem`: `initialize(string uri)`, `updateURI(string)`, `redeemable(...)` override.
+
+## Distinctive mechanic
+Burns are performed by `transferFrom(..., address(0xdEaD), tokenId)` inside a `try/catch` — the extension needs prior approval (`getApproved` or `isApprovedForAll`). When `_redemptionRate == 1`, tokens can be redeemed simply by `safeTransferFrom`-ing them to the extension (the `onERC*Received` hook burns then mints). `redeemERC721` requires `contracts.length == _redemptionRate` exactly. Set variants call `_validateCompleteSet` — every `RedemptionItem` slot must be matched or the whole redemption reverts.
+
+## Pitfalls
+- **`0xdEaD` is not a true burn** — the token still exists on-chain, just unspendable; supply/enumeration on the source contract won't reflect a real burn.
+- Recovery (`setERC721Recoverable`/`recoverERC721`) exists because tokens sent directly with rate != 1 can get stuck; `ERC721BurnRedeemSet.onERC1155Received` (single) always reverts "Incomplete set".
+- `redeemable` returns false once max range fields are zero; ranges with `max == 0` are ignored (`RedeemBase.sol` line 144).
+- `ERC1155ClaimRedeem` guards double-claims via `_claimedERC721`; the reward tokenId must be `initialize`d before `updateURI`.
+- No native membership/fee logic — this is pre-[[burn-redeem]] and lacks the newer merkle/fee/manifold-membership features.
+
+## Open questions
+- Exact deployment status vs the newer [[burn-redeem]] — is this package still deployed anywhere, or purely historical?
+- `ERC1155ClaimRedeem` is abstract; which concrete contract wires the actual claim entrypoint (not present in the files read)?
+
+See also: [[repo-overview]], [[burn-redeem]], [[shared-libraries]].

--- a/docs/llm-wiki/concepts/repo-overview.md
+++ b/docs/llm-wiki/concepts/repo-overview.md
@@ -1,0 +1,84 @@
+---
+title: Repo Overview — creator-core-extensions-solidity
+created: 2026-07-15
+updated: 2026-07-15
+type: overview
+package: repo
+tags: [overview, contract, erc721, erc1155]
+sources: [README.md, manifold/CLAUDE.md, .gitmodules]
+confidence: high
+---
+
+# Repo Overview — creator-core-extensions-solidity
+
+A monorepo of Solidity **extension applications ("Apps")** that install onto any [Manifold Creator Core](https://github.com/manifoldxyz/creator-core-solidity) ERC-721/ERC-1155 contract (deployed via [Manifold Studio](https://studio.manifold.xyz)) to add mint, burn-redeem, edition, metadata, and other mechanics. Pinned to commit `5bc29bd` (2026-03-20). Solidity `^0.8.17`.
+
+## The shared singleton extension model (read this first)
+
+The single most important concept: these are **shared, singleton extensions**, not per-creator deployments.
+
+- ONE instance of e.g. `ERC721LazyPayableClaim` is deployed **per chain**.
+- **Every** creator contract installs that same shared instance as an extension.
+- Each creator registers its own **instance** — a claim / burnRedeem / etc. — keyed by `(creatorContractAddress, instanceId)`.
+- The extension holds the *logic* and the *funds/fee flow*; the creator contract holds the *tokens* and delegates mint/burn to the registered extension via the Creator Core extension interface.
+
+Config for an instance is gated by `AdminControl.creatorAdminRequired(creator)` — only the creator's admins can create/update their instance. Mints emit standard `Instance*Mint` events (see [[shared-libraries]]).
+
+Exceptions: the `edition` and `lazywhitelist` packages use a **Template/Implementation minimal-proxy clone** pattern (one deployed impl, cloned per creator) rather than the multi-creator singleton keyed by instanceId. See [[edition-package]] and [[lazywhitelist-and-fonts]].
+
+## Package map
+
+| Package | What it is | Wiki page |
+|---|---|---|
+| **manifold** | The production extension suite — 13+ families (claims, burn-redeem, editions, singles, metadata, soulbound, gacha, deck, frames, physical, operator-filter) | many (below) |
+| **dynamic** | On-chain dynamic tokenURI — Arweave hash swap, on-chain SVG, time-based | [[dynamic-and-enumerable]] |
+| **edition** | ERC721 numbered & prefix editions via Template/Implementation clones (+ Nifty Gateway variant) | [[edition-package]] |
+| **enumerable** | Owner-enumeration extension for creator ERC721 | [[dynamic-and-enumerable]] |
+| **lazywhitelist** | Lazy mint gated by a Merkle whitelist, clone pattern | [[lazywhitelist-and-fonts]] |
+| **redeem** | The **original/older** burn-redeem implementation (superseded by manifold/burnredeem) | [[redeem-package]] |
+| **fonts** | On-chain WOFF font storage interface (interface only) | [[lazywhitelist-and-fonts]] |
+
+## manifold package — the family map
+
+| Family | Pages |
+|---|---|
+| Lazy Payable Claim (v1 + USDC) | [[lazy-payable-claim]] |
+| Lazy Payable Claim V2 (updatable fee) | [[lazy-payable-claim-v2]] |
+| Burn Redeem (v1 + V2 updatable fee) | [[burn-redeem]] |
+| Cross-Chain Burn | [[cross-chain-burn]] |
+| Deck Claims | [[deck-claims]] |
+| Gacha / Serendipity | [[gacha-serendipity]] |
+| Frame Claims (+ Paymaster) | [[frame-claims]] |
+| Editions & Singles | [[editions-and-singles]] |
+| Collectible | [[collectible]] |
+| Physical Claim | [[physical-claim]] |
+| Frozen Metadata | [[metadata-frozen]] |
+| Soulbound | [[soulbound]] |
+| Operator Filterer | [[operator-filterer]] |
+| Shared libraries / plumbing | [[shared-libraries]] |
+
+## Naming conventions (repo-wide)
+
+- Core/base logic: `*Core.sol` (abstract) — e.g. `LazyPayableClaimCore.sol`, `BurnRedeemCore.sol`.
+- Token-standard concretes: `ERC721*.sol` / `ERC1155*.sol`.
+- Interfaces: `I*.sol`.
+- V2 lives in a **separate directory** with a `V2` suffix (`lazyUpdatableFeeClaim/`, `burnredeemUpdatableFee/`) — the defining V2 change across families is an **updatable Manifold mint fee**.
+- Custom errors over `require` strings; `unchecked { ++i; }` loops; bitmask/packed-struct gas patterns.
+
+## Tooling
+
+- **Foundry primary** (`forge build` / `forge test`), Truffle for legacy tests. Test matrix: Truffle on `edition`/`lazywhitelist`/`redeem`/`manifold`; Forge on `dynamic`/`enumerable`/`manifold`.
+- Each package is independent — `cd packages/<pkg>` then `yarn install` (needs `NPM_TOKEN` for `@manifoldxyz` scoped deps).
+- Submodules: `forge-std` (v1.5.6), `operator-filter-registry` (v1.4.1), `murky` (Merkle trees).
+- Deploy scripts: `packages/manifold/script/*.s.sol`.
+
+## Version lineage (the traps)
+
+- **redeem package** is the ancestor of burn-redeem; **manifold/burnredeem** superseded it, then **burnredeemUpdatableFee** (V2) superseded that. Same for lazyclaim → lazyUpdatableFeeClaim. Always confirm which version a deployed instance is.
+- `edition` package (clone pattern) vs `manifold/edition` (`ManifoldERC721Edition`, singleton) are **different implementations of "editions"** — don't conflate. See [[editions-and-singles]] vs [[edition-package]].
+
+## Open questions
+
+- Per-chain deployed addresses of each shared singleton (live in README/deploy scripts).
+
+Related: [[shared-libraries]], [[lazy-payable-claim]], [[burn-redeem]]

--- a/docs/llm-wiki/concepts/shared-libraries.md
+++ b/docs/llm-wiki/concepts/shared-libraries.md
@@ -1,0 +1,68 @@
+---
+title: Shared Libraries & Cross-Cutting Plumbing
+created: 2026-07-15
+updated: 2026-07-15
+type: concept
+package: manifold
+tags: [library, interface, delegation, membership, admin, event, single, erc721, erc1155]
+sources: [manifold/contracts/libraries/IManifoldExtension.sol, manifold/contracts/libraries/manifold-membership/IManifoldMembership.sol, manifold/contracts/libraries/delegation-registry/IDelegationRegistryV2.sol, manifold/contracts/libraries/delegation-registry/IDelegationRegistry.sol, manifold/contracts/libraries/single-creator/SingleCreatorExtensionBase.sol]
+confidence: high
+---
+
+# Shared Libraries & Cross-Cutting Plumbing
+
+The `contracts/libraries/` directory is **duplicated verbatim in every package** (`manifold`, `dynamic`, `edition`, `enumerable`, `lazywhitelist`, `redeem` each carry their own copy) so each package builds independently. These are the primitives that nearly every extension family in this repo inherits or calls. Understand these once; they recur everywhere.
+
+## The library set (per package `contracts/libraries/`)
+
+| File | Role |
+|---|---|
+| `manifold-membership/IManifoldMembership.sol` | Manifold Membership check — one method, gates the mint fee |
+| `delegation-registry/IDelegationRegistry.sol` | Delegate.xyz **v1** registry interface (delegate-wallet minting) |
+| `delegation-registry/IDelegationRegistryV2.sol` | Delegate.xyz **v2** registry interface (typed delegations) |
+| `single-creator/SingleCreatorExtensionBase.sol` | Base for extensions bound to ONE creator contract |
+| `single-creator/ERC721/…` `ERC1155/…` | ERC721/ERC1155 flavors of the single-creator base |
+| `IManifoldExtension.sol` | Standard mint **events** every extension emits (manifold pkg only) |
+| `IERC721CreatorCoreVersion.sol` | Version-probe interface for the target creator core |
+| `LegacyInterfaces.sol` | Old interface IDs kept for backward-compat ERC165 checks |
+| `ABDKMath64x64.sol` | Fixed-point math lib (vendored; used by dynamic/time extensions) |
+
+## Manifold Membership — the fee gate
+
+`IManifoldMembership.isActiveMember(address) → bool`. Extensions that charge a Manifold platform mint fee (all the claim/burn families) check this: an **active member mints without the platform fee**, a non-member pays it. The fee is separate from the creator's own `cost`/price. This single boolean is why "why was I charged extra" answers always route through membership status. ^[manifold/contracts/libraries/manifold-membership/IManifoldMembership.sol]
+
+## Delegation Registry — mint-for-a-vault
+
+Two versions coexist. `mintFor` / delegate parameters in the claim families let a **delegate (hot) wallet** mint on behalf of a **vault (cold) wallet** that actually holds the allowlist/membership entitlement. v1 (`IDelegationRegistry`) is boolean-per-scope; **v2 (`IDelegationRegistryV2`)** adds a typed `DelegationType {NONE, ALL, CONTRACT, ERC721, ERC20, ERC1155}` model with a `Delegation` struct and a `multicall`. Contracts that support v2 check the registry to confirm `delegate → vault` before crediting the vault's allowlist slot. ^[manifold/contracts/libraries/delegation-registry/IDelegationRegistryV2.sol]
+
+## Standard mint events — `IManifoldExtension`
+
+Every manifold extension emits one of three events on mint, so indexers get a uniform signal keyed by `instanceId`:
+- `InstanceMint(creator, instanceId, minter, tokenAddress, tokenId, quantity)`
+- `InstanceBatchMint(…, tokenIds[], quantity[])`
+- `InstanceRangeMint(…, fromTokenId, toTokenId, quantity)`
+
+`instanceId`, `tokenAddress`, `tokenId` are indexed. This is the canonical way to watch mints across all families. ^[manifold/contracts/libraries/IManifoldExtension.sol]
+
+## Single-creator base
+
+`SingleCreatorExtensionBase` stores one `_creator` address and exposes `creatorContract()`. Extensions that serve a single creator (rather than the shared multi-creator singletons keyed by `(creator, instanceId)`) inherit this to hard-bind their creator at deploy. The ERC721/ERC1155 subclasses add the standard-specific interface checks in `_setCreator`. ^[manifold/contracts/libraries/single-creator/SingleCreatorExtensionBase.sol]
+
+## Inherited-but-external plumbing (from `@manifoldxyz/creator-core-solidity` + `libraries-solidity`)
+
+Not in this repo but every extension leans on it:
+- **`AdminControl`** — owner + admins; the `creatorAdminRequired(creator)` modifier restricts instance config to the creator's admins.
+- **`ICreatorExtensionTokenURI`** — extensions that own metadata implement this; creator core routes `tokenURI` back to the extension.
+- **ERC165** — extensions advertise supported interfaces so creator core can discover their capabilities.
+
+## Pitfalls
+
+- **The libraries dir is copy-pasted per package.** A fix in `manifold/contracts/libraries/` does NOT propagate to `redeem/contracts/libraries/`. Check the package you're actually building.
+- **v1 vs v2 delegation are not interchangeable** — a contract wired for v1 won't read v2 typed delegations and vice versa. Confirm which registry a given family calls.
+- **Membership ≠ allowlist.** Membership waives the *platform* fee; the *creator* cost and any merkle/signature allowlist are independent gates.
+
+## Open questions
+
+- Exact deployed registry addresses per chain (v1 vs v2) live in deploy scripts / README, not here.
+
+Related: [[repo-overview]], [[lazy-payable-claim]], [[burn-redeem]]

--- a/docs/llm-wiki/concepts/soulbound.md
+++ b/docs/llm-wiki/concepts/soulbound.md
@@ -1,0 +1,106 @@
+---
+title: Soulbound Token Extensions
+created: 2026-07-15
+updated: 2026-07-15
+type: concept
+package: manifold
+tags: [contract, abstract, soulbound, erc721, erc1155, admin, pitfall]
+sources: [manifold/contracts/soulbound/Soulbound.sol, manifold/contracts/soulbound/ERC721Soulbound.sol, manifold/contracts/soulbound/ERC1155Soulbound.sol]
+confidence: high
+---
+
+# Soulbound Token Extensions
+
+## What it is
+
+Shared extensions that make Manifold-creator tokens **non-transferable
+(soulbound) by default, while remaining burnable by default**. Enforcement is a
+per-transfer approval hook: the creator core calls the extension's
+`approveTransfer` on every transfer, and the extension returns `false` to veto a
+disallowed move. Soulbound/burnable state is configurable per-contract and
+per-token; the token-level flag OR the contract-level flag can lift a
+restriction. See [[repo-overview]].
+
+## Contract map
+
+| File | Role |
+|------|------|
+| `soulbound/Soulbound.sol` | `abstract` base — storage maps + configuration logic |
+| `soulbound/ERC721Soulbound.sol` | ERC721 impl of `IERC721CreatorExtensionApproveTransfer` |
+| `soulbound/ERC1155Soulbound.sol` | ERC1155 impl of `IERC1155CreatorExtensionApproveTransfer` |
+
+## Base storage & config (`soulbound/Soulbound.sol`)
+
+Four mappings track state (all default `false`, i.e. soulbound + burnable):
+`_tokenNonSoulbound`, `_tokenNonBurnable` (both `address→uint256→bool`),
+`_contractNonSoulbound`, `_contractNonBurnable` (both `address→bool`).
+
+- `_configureContract(address, bool soulbound, bool burnable) internal` — stores the **negation** of each flag.
+- `configureToken(address creator, uint256 tokenId, bool soulbound, bool burnable) external` and its `uint256[] tokenIds` overload — admin-gated per-token config.
+
+All external config is behind
+`creatorAdminRequired`: `require(IAdminControl(creatorContractAddress).isAdmin(msg.sender), "Must be owner or admin")`.
+
+## External surface (traced)
+
+**ERC721** (`soulbound/ERC721Soulbound.sol`):
+- `setApproveTransfer(address creator, bool enabled)` — verifies the creator supports `IERC721CreatorCore` via `ERC165Checker`, then `setApproveTransferExtension(enabled)`.
+- `approveTransfer(address, address from, address to, uint256 tokenId) → bool` (v2) and `approveTransfer(address from, address to, uint256 tokenId) → bool` (v1, iface `0x99cdaa22`) — both delegate to private `_approveTransfer`.
+- `configureContract(address, bool soulbound, bool burnable, string tokenURIPrefix)` — sets URI prefix + calls `_configureContract`.
+- `mintToken(address, address recipient, string tokenURI)`, `setTokenURI(...)` (single + array overloads).
+
+**ERC1155** (`soulbound/ERC1155Soulbound.sol`): mirror surface with array-based
+`approveTransfer(... uint256[] tokenIds, uint256[])` (v1 iface `0x93a80b14`),
+`mintNewToken`, `mintExistingToken`, and `setTokenURI` overloads.
+
+## Enforcement mechanism
+
+The veto lives in `_approveTransfer` (ERC721, `soulbound/ERC721Soulbound.sol`
+lines 57–61):
+
+```
+if (from == address(0)) return true;               // mint always allowed
+if (to == address(0))   return !(_tokenNonBurnable[msg.sender][tokenId]
+                                 || _contractNonBurnable[msg.sender]); // burn
+return _tokenNonSoulbound[msg.sender][tokenId]
+       || _contractNonSoulbound[msg.sender];        // ordinary transfer
+```
+
+`msg.sender` here is the **creator contract** calling back into the extension.
+Mints (`from == 0`) always pass. Burns (`to == 0`) pass unless marked
+non-burnable. Ordinary transfers pass **only** if the token or its contract has
+been flipped non-soulbound — otherwise the extension returns `false` and the
+creator core reverts the transfer. The ERC1155 variant applies the same logic
+in a loop over `tokenIds` (`soulbound/ERC1155Soulbound.sol` lines 54–66), and
+its transfer branch uses AND-of-negations, so a mixed batch fails if **any**
+token is still soulbound.
+
+Enforcement is only active once an admin calls `setApproveTransfer(creator,
+true)` — this flips the creator core's per-extension approve-transfer check on.
+
+## Relationship to operator filtering
+
+Both soulbound contracts implement the same
+`IERC*CreatorExtensionApproveTransfer` hook that the operator-filter extensions
+use — they are alternative consumers of the creator's single approve-transfer
+slot. A creator can install soulbound **or** an operator filterer on that hook,
+not trivially both. See [[operator-filterer]] and [[shared-libraries]].
+
+## Pitfalls
+
+- **Double negatives.** Storage records `Non*` flags; a stored `true` means the
+  restriction is lifted. Reading the maps directly inverts intuition.
+- **OR semantics.** A token is transferable if the token-level OR contract-level
+  non-soulbound flag is set; you cannot re-soulbind a single token once the whole
+  contract is marked non-soulbound.
+- Enforcement is inert until `setApproveTransfer(creator, true)` is called — a
+  creator that merely deploys/registers the extension without enabling the check
+  gets freely transferable tokens.
+- ERC1155 batch transfers are all-or-nothing: one still-soulbound token in the
+  batch vetoes the entire transfer.
+
+## Open questions
+
+- Behavior if a creator has approve-transfer disabled at the core level while
+  soulbound state is configured — presumably no enforcement (needs
+  `creator-core-solidity` confirmation).

--- a/docs/llm-wiki/index.md
+++ b/docs/llm-wiki/index.md
@@ -1,0 +1,43 @@
+# Wiki Index — creator-core-extensions-solidity
+
+> Content catalog for the [manifoldxyz/creator-core-extensions-solidity](https://github.com/manifoldxyz/creator-core-extensions-solidity) knowledge base.
+> Every page listed under its section with a one-line "the thing to know."
+> Read [[repo-overview]] first, then jump to the family you need.
+> Last updated: 2026-07-15 | Total pages: 19 | Repo pinned: commit 5bc29bd (2026-03-20)
+
+## Start Here
+
+- [[repo-overview]] — Architecture, package map, and the **shared singleton extension model**: one instance per chain, every creator installs it, instances keyed by `(creatorContractAddress, instanceId)`.
+- [[shared-libraries]] — The copy-pasted-per-package plumbing: `IManifoldMembership` (waives platform fee), delegation registry v1/v2 (`mintFor` a vault), standard `Instance*Mint` events, single-creator base.
+
+## Claim Families (manifold)
+
+- [[lazy-payable-claim]] — ETH/USDC lazy claims. **Gotcha:** a claim with a non-zero `signingAddress` can ONLY be minted via `mintSignature`; `mint`/`mintBatch`/`mintProxy` hard-revert `MustUseSignatureMinting`, and proxy/signature paths never waive the platform fee.
+- [[lazy-payable-claim-v2]] — Updatable-fee variant. **Gotcha:** the ONLY real change is `MINT_FEE`/`MINT_FEE_MERKLE` became mutable and **default to 0** — a fresh V2 deploy collects no platform fee until the owner calls `setMintFees`.
+- [[deck-claims]] — Card-deck reveals. **Gotcha:** no user mint/payment path at all — `initializeClaim` mints zero-supply variation token IDs and a trusted signer deals them via `deliverMints`; fairness is 100% off-chain signer trust.
+- [[gacha-serendipity]] — Randomized gacha. **Gotcha:** randomness is entirely off-chain — collectors `mintReserve` (paying `cost + 0.0005 ETH`, contract callers blocked), backend signer picks winners and calls `deliverMints`; on-chain only guarantees `delivered ≤ reserved`.
+- [[frame-claims]] — Farcaster Frame mints + Paymaster. **Gotcha:** paymaster signature is recovered from a raw `bytes32` with NO EIP-191 prefix, with per-`(fid, nonce)` replay protection; 5 free sponsored mints then 0.0001 ETH each, paid XOR sponsored.
+- [[collectible]] — Signature-gated purchase/premint. **Gotcha:** not merkle — every claim/purchase is an ECDSA sig over `(msg.sender, nonce)` so payloads are sender-bound and non-relayable; `purchaseMax != 0` doubles as the init sentinel.
+
+## Burn / Redeem Families (manifold)
+
+- [[burn-redeem]] — v1 + V2 burn-to-redeem (`BurnItem`/`BurnGroup`/`BurnRedeem`). **Gotcha:** in V2 the burn fees are mutable and **default to 0** (constructor never sets them) — nothing collected until an admin calls `setBurnFees`; v1 hardcodes 0.00069/0.00099 ETH.
+- [[cross-chain-burn]] — Burn here, fulfill elsewhere. **Gotcha:** this contract NEVER mints — it only burns, bumps a counter, and emits `CrossChainBurn` for an off-chain fulfiller; all trust rests on one `_signingAddress` ECDSA sig, no on-chain cross-chain proof.
+- [[physical-claim]] — Burn/mark a token to redeem a physical item. **Gotcha:** no on-chain instance config and no `initialize` — ALL economic terms live inside the server-signed `BurnSubmission`; `ERC721_NO_BURN` marks a token used without burning it.
+- [[redeem-package]] — The **legacy** burn-redeem (package `redeem`), superseded by [[burn-redeem]]. **Gotcha:** "burns" are actually `transferFrom(..., 0xdEaD, ...)` pseudo-burns, so source-contract supply/enumeration never reflects them.
+
+## Edition / Single Families
+
+- [[editions-and-singles]] — `ManifoldERC721Edition` + 1/1 singles (manifold pkg). **Gotcha:** token→instance indexing forks on creator `VERSION()` — v3+ packs `instanceId<<24|index`; pre-v3 reverse-scans `IndexRange[]` (gas grows with mint history). Not payable, no fee logic.
+- [[edition-package]] — Numbered/prefix editions via minimal-proxy clones (package `edition`, incl. Nifty Gateway variant). **Gotcha:** EIP-1967 clone `initialize` pattern; `IndexRange`s only coalesce for contiguous mints — interleaved extension mints fragment them.
+
+## Utility Extensions (manifold)
+
+- [[metadata-frozen]] — Immutable-tokenURI mints. **Gotcha:** "frozen" is structural, not a runtime lock — the extension just exposes no URI-mutation entrypoint, but a *different* admin extension on the same creator still could rewrite the URI.
+- [[soulbound]] — Non-transferable tokens. **Gotcha:** completely inert until an admin calls `setApproveTransfer(creator, true)`; enforcement is the `approveTransfer` veto where `msg.sender` is the creator contract; soulbound+burnable by default (inverted `Non*` flags).
+- [[operator-filterer]] — OpenSea operator filtering. **Gotcha:** blocked operators cause a **revert with a custom error** (not a `false` return); `from == operator` always bypasses; `CreatorOperatorFilterer` keys blocklists per-creator by `msg.sender` despite being one shared deploy.
+
+## Other Packages
+
+- [[dynamic-and-enumerable]] — On-chain dynamic tokenURI (Arweave hash / SVG / time-based) + owner-enumeration extension. Two packages, two sections.
+- [[lazywhitelist-and-fonts]] — Merkle-gated lazy mint (clone pattern) + on-chain WOFF fonts. **Gotcha:** `ERC721LazyMintWhitelistBase` hardcodes `MINT_PRICE = 0.1 ether` / `MAX_MINTS = 50` with no setter (reference code, not production); Fonts ships interface-only.

--- a/docs/llm-wiki/log.md
+++ b/docs/llm-wiki/log.md
@@ -1,0 +1,25 @@
+# Wiki Log
+
+> Chronological record of all wiki actions. Append-only.
+> Format: `## [YYYY-MM-DD] action | subject`
+> Actions: ingest, update, query, lint, create, archive
+
+## [2026-07-15] create | Wiki initialized
+- Domain: manifoldxyz/creator-core-extensions-solidity (Solidity NFT extension apps)
+- Repo pinned to commit 5bc29bd (2026-03-20)
+- Structure created: SCHEMA.md, index.md, log.md, concepts/, reference/, comparisons/, queries/
+- Source survey: 7 packages, ~90 non-lib .sol files (manifold=92 incl. libs, the dominant package)
+
+## [2026-07-15] ingest | Full repo seeded — 19 concept pages
+- Read ~90 non-lib .sol across 7 packages at commit 5bc29bd
+- Parent-written: repo-overview.md, shared-libraries.md
+- Subagent-seeded (6 parallel leaf agents, all traced to source):
+  - lazy-payable-claim, lazy-payable-claim-v2, burn-redeem, cross-chain-burn,
+    deck-claims, gacha-serendipity, frame-claims, editions-and-singles,
+    collectible, physical-claim, metadata-frozen, soulbound, operator-filterer,
+    redeem-package, edition-package, dynamic-and-enumerable, lazywhitelist-and-fonts
+- index.md written from per-page gotcha one-liners
+- Lint: 19 pages, 0 broken wikilinks, 0 orphans, 0 missing frontmatter, all <200 lines
+
+## [2026-07-15] lint | 0 issues
+- broken links: 0 | orphans: 0 | missing frontmatter: 0 | oversized pages: 0


### PR DESCRIPTION
## Objective

Add an interlinked, source-grounded knowledge base for this repo so humans and AI agents can understand the contract families fast — without re-reading ~90 `.sol` files.

Lives at `docs/llm-wiki/`. Follows the [Karpathy LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) pattern: a directory of interlinked markdown, no tooling required. Open in Obsidian/VS Code for clickable navigation, or start at `docs/llm-wiki/index.md`.

## Summary

- **19 concept pages** covering all 7 packages (`manifold`, `dynamic`, `edition`, `enumerable`, `lazywhitelist`, `redeem`, `fonts`) and every manifold extension family — claims (lazy v1/v2, deck, gacha, frame, collectible), burn/redeem (v1/v2, cross-chain, physical, legacy redeem pkg), editions/singles, and utilities (frozen-metadata, soulbound, operator-filterer).
- **`index.md`** — sectioned catalog, each page with a one-line "the thing to know."
- **`SCHEMA.md`** — conventions, tag taxonomy, and honesty rules.
- **`README.md`** — orientation for a repo visitor.
- **`log.md`** — build/maintenance log.

## How it was built

Every function signature, struct field, event, and error is **traced to a real source file** (cited as inline paths relative to `packages/`). No invented signatures — pages document the code as written. Generated by reading the actual Solidity at the current `main` commit, then lint-verified.

## Quality gates

- Zero broken `[[wikilinks]]`
- Zero orphan pages (every page has inbound links)
- Every page has complete YAML frontmatter + a source citation
- Every page under 200 lines

## Notes

- Docs-only change — no contract, test, or build changes.
- The mental model the wiki centers on: these are **shared singleton extensions** (one instance per chain, every creator installs it, instances keyed by `(creatorContractAddress, instanceId)`) — the #1 thing to get right about this repo.
