### PR TITLE
docs: point agents at the LLM wiki for context gathering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md — creator-core-extensions-solidity
+
+## Gather context from the LLM wiki FIRST
+
+This repo has a source-grounded knowledge base at **`docs/llm-wiki/`**. Before exploring `packages/**/*.sol` by hand, use the wiki — it answers most "what does X do / how do the families relate" questions in one or two file reads instead of dozens.
+
+### How to use it
+
+1. **Start at `docs/llm-wiki/index.md`** — a sectioned catalog of all 19 concept pages, each with a one-line "the thing to know" (including the sharpest gotchas, e.g. V2 fees default to 0).
+2. **Read `docs/llm-wiki/concepts/repo-overview.md`** for the architecture: the **shared singleton extension model** (one instance per chain, every creator installs it, instances keyed by `(creatorContractAddress, instanceId)`), the package map, and version lineage traps (redeem → burnredeem → burnredeemUpdatableFee; lazyclaim → lazyUpdatableFeeClaim).
+3. **Jump to the family page** for whatever you're touching (e.g. `concepts/lazy-payable-claim.md`, `concepts/burn-redeem.md`). Each page has: contract map, real struct fields, external function signatures, fee/membership handling, and pitfalls — every claim cited to a `.sol` path relative to `packages/`.
+4. **Cross-cutting plumbing** (membership fee gate, delegation registry v1/v2, standard `Instance*Mint` events, single-creator base) lives in `concepts/shared-libraries.md`.
+5. **Verify against source before writing code.** The wiki is pinned to the commit noted in its `index.md` header. If the contract has changed since, the source wins — then update the wiki page.
+
+### Keep the wiki current
+
+If your change alters a documented behavior (signatures, structs, fees, mechanics):
+- Update the relevant `docs/llm-wiki/concepts/*.md` page and bump its `updated` frontmatter date.
+- Adjust its one-liner in `docs/llm-wiki/index.md` if the "thing to know" changed.
+- Append an entry to `docs/llm-wiki/log.md`.
+- Rules and tag taxonomy: `docs/llm-wiki/SCHEMA.md`. Never invent a signature — cite the `.sol` path or leave it out.
+
+## Repo basics
+
+- Monorepo of independent packages under `packages/` (`manifold` is the production suite). Build/test per package: `cd packages/<pkg>` then `forge build` / `forge test` (Foundry-primary; Truffle legacy for `edition`, `lazywhitelist`, `redeem`, `manifold`).
+- `yarn install` per package requires `NPM_TOKEN` for `@manifoldxyz` scoped deps. Clone with `--recurse-submodules` (forge-std, operator-filter-registry, murky).
+- Per-package agent guidance: `packages/manifold/CLAUDE.md` (conventions, gas patterns, custom errors).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# CLAUDE.md — creator-core-extensions-solidity
+
+See **[AGENTS.md](./AGENTS.md)** for full agent guidance. The short version:
+
+## Gather context from the LLM wiki FIRST
+
+Before exploring `packages/**/*.sol` by hand, read the knowledge base at **`docs/llm-wiki/`**:
+
+1. **`docs/llm-wiki/index.md`** — catalog of all concept pages, each with a one-line "the thing to know."
+2. **`docs/llm-wiki/concepts/repo-overview.md`** — the shared singleton extension model (one instance per chain, instances keyed by `(creatorContractAddress, instanceId)`), package map, version lineage traps.
+3. **`docs/llm-wiki/concepts/<family>.md`** — per-family contract maps, real signatures/structs, fee handling, pitfalls; every claim cited to a `.sol` path.
+4. Wiki is pinned to the commit in its `index.md` header — **source wins on conflict**; update the wiki page when you change documented behavior (see `docs/llm-wiki/SCHEMA.md`).
+
+Package-level conventions (gas patterns, custom errors, naming): `packages/manifold/CLAUDE.md`.

--- a/packages/manifold/CLAUDE.md
+++ b/packages/manifold/CLAUDE.md
@@ -1,5 +1,7 @@
 # CLAUDE.md - AI Assistant Guidelines
 
+> **Gather context first:** this repo has a source-grounded LLM wiki at the repo root — `docs/llm-wiki/`. Start at `docs/llm-wiki/index.md` (catalog + per-family gotchas), then the family page for whatever you're touching (e.g. `concepts/lazy-payable-claim.md`, `concepts/burn-redeem.md`). It documents contract maps, real signatures/structs, fee handling, and pitfalls for every family in this package, each claim cited to source. On conflict, source wins — then update the wiki page.
+
 ## Project Overview
 **Manifold Creator Core Extensions** - Solidity smart contracts providing extension functionality for [Manifold Creator Core](https://github.com/manifoldxyz/creator-core-solidity) NFT contracts deployed via [Manifold Studio](https://studio.manifold.xyz).
 


### PR DESCRIPTION
## Objective

Follow-up to #117: make agents (Claude Code, Codex, etc.) actually USE the new `docs/llm-wiki/` when working in this repo, instead of re-exploring `packages/**/*.sol` by hand.

## Summary

- **Root `AGENTS.md`** (new) — "gather context from the LLM wiki FIRST" workflow: `index.md` → `concepts/repo-overview.md` → the family page for whatever you're touching → `shared-libraries.md` for cross-cutting plumbing. Includes the maintenance rule (source wins on conflict; when changing documented behavior, update the concept page + index one-liner + log) and repo basics (per-package Foundry/Truffle builds, NPM_TOKEN, submodules).
- **Root `CLAUDE.md`** (new) — condensed version of the same, pointing to AGENTS.md.
- **`packages/manifold/CLAUDE.md`** — added a one-paragraph pointer at the top so agents starting inside the package also find the wiki.

## Test plan

- Docs-only; no contract, test, or build changes.
- All referenced paths exist on `main` (`docs/llm-wiki/index.md`, `concepts/repo-overview.md`, `concepts/shared-libraries.md`, `SCHEMA.md`).
